### PR TITLE
feat: set up CSS design system for Leptos frontend

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1967,6 +1967,7 @@ name = "server"
 version = "0.2.0"
 dependencies = [
  "axum",
+ "regex",
  "reqwest",
  "serde",
  "serde_json",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -511,7 +511,7 @@ dependencies = [
 
 [[package]]
 name = "frontend"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "leptos",
  "wasm-bindgen",
@@ -1964,7 +1964,7 @@ dependencies = [
 
 [[package]]
 name = "server"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "axum",
  "reqwest",

--- a/docs/css-design-system.md
+++ b/docs/css-design-system.md
@@ -13,7 +13,7 @@ The LibreChat frontend uses **traditional CSS stylesheets** — no CSS framework
 
 ### File Layout
 
-```
+```text
 frontend/
 ├── index.html          ← references main.css via Trunk link tag
 ├── style/
@@ -37,7 +37,7 @@ All visual constants are defined as CSS custom properties in `:root` inside `mai
 | `--color-text-secondary` | `#9ca3af` | Muted/secondary text |
 | `--color-accent` | `#3b82f6` | Accent/brand colour (blue) |
 | `--color-accent-hover` | `#2563eb` | Accent hover state |
-| `--color-border` | `4b5563` | Border colour |
+| `--color-border` | `#4b5563` | Border colour |
 | `--font-sans` | `system-ui, -apple-system, sans-serif` | Body font stack |
 | `--font-mono` | `ui-monospace, "Cascadia Code", "Fira Code", monospace` | Code block font stack |
 | `--radius-sm` | `0.25rem` | Small border radius |
@@ -62,11 +62,11 @@ Additional tokens for spacing (`--space-*`), shadows (`--shadow-*`), and transit
 | `.flex-column-full` | Generic full-height flex column |
 | `.scroll-area` | Flex-grow scrollable region (for message history) |
 | `.sticky-input` | Flex-shrink pinned bottom bar (for chat input) |
-| `.message-list` | Vertical flex list with gaps for chat messages |
-| `.message-bubble` | Base message bubble styling |
-| `.message-bubble--user` | Right-aligned user message (accent background) |
-| `.message-bubble--assistant` | Left-aligned assistant message (secondary background) |
-| `.chat-input` | Flex row with textarea and send button |
+| `.message-list` | Vertical flex list with gaps for chat messages *(planned)* |
+| `.message-bubble` | Base message bubble styling *(planned)* |
+| `.message-bubble--user` | Right-aligned user message (accent background) *(planned)* |
+| `.message-bubble--assistant` | Left-aligned assistant message (secondary background) *(planned)* |
+| `.chat-input` | Flex row with textarea and send button *(planned)* |
 | `.sr-only` | Screen-reader-only hidden text |
 
 ## API Reference

--- a/docs/css-design-system.md
+++ b/docs/css-design-system.md
@@ -1,0 +1,97 @@
+# CSS Design System
+
+## Architecture & Design
+
+The LibreChat frontend uses **traditional CSS stylesheets** — no CSS frameworks or preprocessors. All styles live under `frontend/style/` and are copied into the Trunk build output via `<link data-trunk rel="stylesheet">` tags in `frontend/index.html`.
+
+### Why Traditional CSS?
+
+- **Zero runtime cost** — no JavaScript framework overhead for class generation.
+- **WASM-friendly** — styles are static assets bundled by Trunk; no build-time JS toolchain required.
+- **Low resource footprint** — consistent with the project's Raspberry Pi target.
+- **Explicit and auditable** — all styles are in plain `.css` files, easy to grep and review.
+
+### File Layout
+
+```
+frontend/
+├── index.html          ← references main.css via Trunk link tag
+├── style/
+│   └── main.css        ← global stylesheet (design tokens + reset + utilities)
+└── src/
+    └── lib.rs          ← Leptos App component with class="app-root"
+```
+
+Additional stylesheets can be added to `frontend/style/` and referenced in `index.html` as the project grows.
+
+## Design Tokens
+
+All visual constants are defined as CSS custom properties in `:root` inside `main.css`:
+
+| Token | Default | Purpose |
+|---|---|---|
+| `--color-bg-primary` | `#111827` | Page background (dark) |
+| `--color-bg-secondary` | `#1f2937` | Card/panel background |
+| `--color-bg-input` | `#374151` | Input field background |
+| `--color-text-primary` | `#f9fafb` | Primary text colour |
+| `--color-text-secondary` | `#9ca3af` | Muted/secondary text |
+| `--color-accent` | `#3b82f6` | Accent/brand colour (blue) |
+| `--color-accent-hover` | `#2563eb` | Accent hover state |
+| `--color-border` | `4b5563` | Border colour |
+| `--font-sans` | `system-ui, -apple-system, sans-serif` | Body font stack |
+| `--font-mono` | `ui-monospace, "Cascadia Code", "Fira Code", monospace` | Code block font stack |
+| `--radius-sm` | `0.25rem` | Small border radius |
+| `--radius-md` | `0.5rem` | Medium border radius |
+| `--radius-lg` | `0.75rem` | Large border radius |
+
+Additional tokens for spacing (`--space-*`), shadows (`--shadow-*`), and transitions (`--transition-*`) are also defined.
+
+## Base Reset
+
+`main.css` includes a minimal reset:
+
+- **Box-sizing**: `border-box` on all elements.
+- **Margin/padding**: Zeroed on all elements via `*, *::before, *::after`.
+- **HTML/body**: Full height (`100%`), system font stack, dark background, light text, antialiased rendering.
+
+## Layout Utility Classes
+
+| Class | Purpose |
+|---|---|
+| `.app-root` | Full-height flex column; the root container for the Leptos app |
+| `.flex-column-full` | Generic full-height flex column |
+| `.scroll-area` | Flex-grow scrollable region (for message history) |
+| `.sticky-input` | Flex-shrink pinned bottom bar (for chat input) |
+| `.message-list` | Vertical flex list with gaps for chat messages |
+| `.message-bubble` | Base message bubble styling |
+| `.message-bubble--user` | Right-aligned user message (accent background) |
+| `.message-bubble--assistant` | Left-aligned assistant message (secondary background) |
+| `.chat-input` | Flex row with textarea and send button |
+| `.sr-only` | Screen-reader-only hidden text |
+
+## API Reference
+
+There are no Rust APIs in this issue — the design system is purely CSS. The Leptos `App` component applies the `app-root` class to its root `<div>`.
+
+## Configuration
+
+No environment variables or feature flags are introduced. The dark theme is the default and only theme in this phase. Theme switching will be added in a future issue.
+
+## Testing Guide
+
+Run the design system integration tests:
+
+```bash
+cargo test -p server --test css_design_system
+```
+
+These tests verify:
+- `frontend/style/main.css` exists and contains all required CSS custom properties.
+- Reset styles (box-sizing, margin, padding) are present.
+- Layout utility classes (`.app-root`, `.scroll-area`, `.sticky-input`, `.flex-column-full`) are defined.
+- `frontend/index.html` references `main.css` via a Trunk stylesheet link tag.
+- The Leptos `App` component uses the `app-root` class.
+
+## Migration / Upgrade Notes
+
+This is the initial setup — no migration needed. Future UI issues should use the design tokens and utility classes defined here rather than hardcoding values.

--- a/frontend/Cargo.toml
+++ b/frontend/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "frontend"
-version = "0.1.0"
+version = "0.2.0"
 edition = "2024"
 
 [dependencies]

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -4,6 +4,7 @@
     <meta charset="utf-8"/>
     <meta name="viewport" content="width=device-width, initial-scale=1"/>
     <title>LibreChat</title>
+    <link data-trunk rel="stylesheet" href="style/main.css"/>
     <link data-trunk rel="rust" data-wasm-cargo="frontend"/>
 </head>
 <body></body>

--- a/frontend/src/lib.rs
+++ b/frontend/src/lib.rs
@@ -4,7 +4,9 @@ use wasm_bindgen::prelude::*;
 #[component]
 pub fn App() -> impl IntoView {
     view! {
-        <p>"Hello from Leptos!"</p>
+        <div class="app-root">
+            <p>"Hello from Leptos!"</p>
+        </div>
     }
 }
 

--- a/frontend/style/main.css
+++ b/frontend/style/main.css
@@ -1,0 +1,142 @@
+/* ==========================================================================
+   LibreChat Design System — Global Stylesheet
+   ========================================================================== */
+
+/* --------------------------------------------------------------------------
+   1. Design Tokens (CSS Custom Properties)
+   -------------------------------------------------------------------------- */
+:root {
+  /* Colour palette — dark theme */
+  --color-bg-primary: #111827;
+  --color-bg-secondary: #1f2937;
+  --color-bg-input: #374151;
+  --color-text-primary: #f9fafb;
+  --color-text-secondary: #9ca3af;
+  --color-accent: #3b82f6;
+  --color-accent-hover: #2563eb;
+  --color-border: #4b5563;
+
+  /* Typography */
+  --font-sans: system-ui, -apple-system, sans-serif;
+  --font-mono: ui-monospace, "Cascadia Code", "Fira Code", monospace;
+
+  /* Spacing scale */
+  --space-xs: 0.25rem;
+  --space-sm: 0.5rem;
+  --space-md: 1rem;
+  --space-lg: 1.5rem;
+  --space-xl: 2rem;
+
+  /* Border radii */
+  --radius-sm: 0.25rem;
+  --radius-md: 0.5rem;
+  --radius-lg: 0.75rem;
+
+  /* Shadows */
+  --shadow-sm: 0 1px 2px rgba(0, 0, 0, 0.3);
+  --shadow-md: 0 4px 6px rgba(0, 0, 0, 0.4);
+
+  /* Transitions */
+  --transition-fast: 150ms ease;
+  --transition-normal: 250ms ease;
+}
+
+/* --------------------------------------------------------------------------
+   2. Base Reset
+   -------------------------------------------------------------------------- */
+*,
+*::before,
+*::after {
+  box-sizing: border-box;
+  margin: 0;
+  padding: 0;
+}
+
+html,
+body {
+  height: 100%;
+  font-family: var(--font-sans);
+  font-size: 16px;
+  line-height: 1.5;
+  color: var(--color-text-primary);
+  background-color: var(--color-bg-primary);
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+}
+
+a {
+  color: var(--color-accent);
+  text-decoration: none;
+}
+
+a:hover {
+  color: var(--color-accent-hover);
+}
+
+/* --------------------------------------------------------------------------
+   3. Layout Utilities
+   -------------------------------------------------------------------------- */
+
+/* Full-height flex column — used for the app root and chat shell */
+.flex-column-full {
+  display: flex;
+  flex-direction: column;
+  height: 100%;
+}
+
+/* Scrollable message area — fills remaining vertical space */
+.scroll-area {
+  flex: 1 1 0;
+  overflow-y: auto;
+  padding: var(--space-md);
+}
+
+/* Sticky input bar pinned to the bottom */
+.sticky-input {
+  flex-shrink: 0;
+  padding: var(--space-sm) var(--space-md);
+  border-top: 1px solid var(--color-border);
+  background-color: var(--color-bg-secondary);
+}
+
+/* --------------------------------------------------------------------------
+   4. App Root
+   -------------------------------------------------------------------------- */
+.app-root {
+  display: flex;
+  flex-direction: column;
+  height: 100%;
+  background-color: var(--color-bg-primary);
+  color: var(--color-text-primary);
+}
+
+/* --------------------------------------------------------------------------
+   5. Scrollbar Styling (Webkit)
+   -------------------------------------------------------------------------- */
+.scroll-area::-webkit-scrollbar {
+  width: 6px;
+}
+
+.scroll-area::-webkit-scrollbar-track {
+  background: transparent;
+}
+
+.scroll-area::-webkit-scrollbar-thumb {
+  background-color: var(--color-border);
+  border-radius: 3px;
+}
+
+/* --------------------------------------------------------------------------
+   6. Utility — Screen-reader only (accessible hidden text)
+   -------------------------------------------------------------------------- */
+.sr-only {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border: 0;
+}

--- a/frontend/style/main.css
+++ b/frontend/style/main.css
@@ -66,11 +66,16 @@ body {
 
 a {
   color: var(--color-accent);
-  text-decoration: none;
+  text-decoration: underline;
 }
 
 a:hover {
   color: var(--color-accent-hover);
+}
+
+a:focus-visible {
+  outline: 2px solid var(--color-accent);
+  outline-offset: 2px;
 }
 
 /* --------------------------------------------------------------------------
@@ -136,7 +141,7 @@ a:hover {
   padding: 0;
   margin: -1px;
   overflow: hidden;
-  clip: rect(0, 0, 0, 0);
+  clip-path: inset(50%);
   white-space: nowrap;
   border: 0;
 }

--- a/frontend/style/main.css
+++ b/frontend/style/main.css
@@ -92,6 +92,7 @@ a:focus-visible {
 /* Scrollable message area — fills remaining vertical space */
 .scroll-area {
   flex: 1 1 0;
+  min-height: 0;
   overflow-y: auto;
   padding: var(--space-md);
 }

--- a/server/Cargo.toml
+++ b/server/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "server"
-version = "0.1.0"
+version = "0.2.0"
 edition = "2024"
 
 [dependencies]

--- a/server/Cargo.toml
+++ b/server/Cargo.toml
@@ -13,3 +13,4 @@ tower-http = { workspace = true }
 
 [dev-dependencies]
 toml = "0.8"
+regex = "1"

--- a/server/tests/css_design_system.rs
+++ b/server/tests/css_design_system.rs
@@ -1,0 +1,213 @@
+//! Integration tests verifying the CSS design system and stylesheet setup (Issue #2).
+
+use std::path::Path;
+
+/// Returns the normalized workspace root directory.
+fn workspace_root() -> &'static Path {
+    Path::new(env!("CARGO_MANIFEST_DIR")).parent().unwrap()
+}
+
+fn read_main_css() -> String {
+    let path = workspace_root()
+        .join("frontend")
+        .join("style")
+        .join("main.css");
+    assert!(path.exists(), "frontend/style/main.css is missing");
+    std::fs::read_to_string(&path).expect("failed to read frontend/style/main.css")
+}
+
+fn read_index_html() -> String {
+    let path = workspace_root().join("frontend").join("index.html");
+    assert!(path.exists(), "frontend/index.html is missing");
+    std::fs::read_to_string(&path).expect("failed to read frontend/index.html")
+}
+
+fn read_app_lib_rs() -> String {
+    let path = workspace_root().join("frontend").join("src").join("lib.rs");
+    assert!(path.exists(), "frontend/src/lib.rs is missing");
+    std::fs::read_to_string(&path).expect("failed to read frontend/src/lib.rs")
+}
+
+// ---- CSS file existence and custom properties ----
+
+#[test]
+fn test_main_css_exists() {
+    let path = workspace_root()
+        .join("frontend")
+        .join("style")
+        .join("main.css");
+    assert!(path.exists(), "frontend/style/main.css must exist");
+}
+
+#[test]
+fn test_css_custom_properties_defined_in_root() {
+    let css = read_main_css();
+
+    let required_vars = [
+        "--color-bg-primary",
+        "--color-bg-secondary",
+        "--color-bg-input",
+        "--color-text-primary",
+        "--color-text-secondary",
+        "--color-accent",
+        "--color-accent-hover",
+        "--color-border",
+        "--font-sans",
+        "--font-mono",
+        "--radius-sm",
+        "--radius-md",
+        "--radius-lg",
+    ];
+
+    for var in &required_vars {
+        assert!(
+            css.contains(var),
+            "main.css must define CSS custom property `{var}` in :root"
+        );
+    }
+}
+
+#[test]
+fn test_css_custom_property_values() {
+    let css = read_main_css();
+
+    // Spot-check specific values from the issue requirements
+    assert!(
+        css.contains("#111827"),
+        "main.css must set --color-bg-primary to #111827"
+    );
+    assert!(
+        css.contains("#1f2937"),
+        "main.css must set --color-bg-secondary to #1f2937"
+    );
+    assert!(
+        css.contains("#374151"),
+        "main.css must set --color-bg-input to #374151"
+    );
+    assert!(
+        css.contains("#3b82f6"),
+        "main.css must set --color-accent to #3b82f6"
+    );
+    assert!(
+        css.contains("#2563eb"),
+        "main.css must set --color-accent-hover to #2563eb"
+    );
+    assert!(
+        css.contains("#4b5563"),
+        "main.css must set --color-border to #4b5563"
+    );
+}
+
+#[test]
+fn test_css_dark_theme_default() {
+    let css = read_main_css();
+
+    // Verify dark background is set on body/html
+    assert!(
+        css.contains("background-color") && css.contains("var(--color-bg-primary)"),
+        "Dark theme must be applied as default via background-color referencing --color-bg-primary"
+    );
+
+    // Verify light text is the default
+    assert!(
+        css.contains("color") && css.contains("var(--color-text-primary)"),
+        "Dark theme must use --color-text-primary for default text color"
+    );
+}
+
+// ---- Base reset styles ----
+
+#[test]
+fn test_css_reset_box_sizing() {
+    let css = read_main_css();
+    assert!(
+        css.contains("box-sizing") && css.contains("border-box"),
+        "Reset must set box-sizing: border-box"
+    );
+}
+
+#[test]
+fn test_css_reset_margin_padding() {
+    let css = read_main_css();
+    // Check that margin and padding are reset to 0
+    assert!(
+        css.contains("margin: 0") || css.contains("margin:0"),
+        "Reset must set margin to 0"
+    );
+    assert!(
+        css.contains("padding: 0") || css.contains("padding:0"),
+        "Reset must set padding to 0"
+    );
+}
+
+// ---- Layout utility classes ----
+
+#[test]
+fn test_css_has_app_root_class() {
+    let css = read_main_css();
+    assert!(
+        css.contains(".app-root"),
+        "main.css must define the .app-root class"
+    );
+}
+
+#[test]
+fn test_css_has_scroll_area_class() {
+    let css = read_main_css();
+    assert!(
+        css.contains(".scroll-area") || css.contains(".message-list"),
+        "main.css must define a scrollable area utility class for the chat layout"
+    );
+}
+
+#[test]
+fn test_css_has_sticky_input_class() {
+    let css = read_main_css();
+    assert!(
+        css.contains(".sticky-input") || css.contains(".chat-input"),
+        "main.css must define a sticky input utility class for the chat layout"
+    );
+}
+
+#[test]
+fn test_css_has_flex_column_full_class() {
+    let css = read_main_css();
+    assert!(
+        css.contains(".flex-column-full") || css.contains("flex-direction: column"),
+        "main.css must define a flex-column layout utility"
+    );
+}
+
+// ---- index.html references stylesheet ----
+
+#[test]
+fn test_index_html_references_stylesheet() {
+    let html = read_index_html();
+
+    assert!(
+        html.contains("data-trunk") && html.contains("stylesheet") && html.contains("main.css"),
+        "index.html must reference main.css via a <link data-trunk rel=\"stylesheet\" .../> tag"
+    );
+}
+
+#[test]
+fn test_index_html_still_has_rust_tag() {
+    let html = read_index_html();
+
+    assert!(
+        html.contains("data-trunk") && html.contains("data-wasm-cargo"),
+        "index.html must still contain the Trunk Rust/WASM entrypoint tag"
+    );
+}
+
+// ---- Leptos component uses app-root class ----
+
+#[test]
+fn test_app_component_uses_app_root_class() {
+    let lib_rs = read_app_lib_rs();
+
+    assert!(
+        lib_rs.contains("app-root"),
+        "Leptos App component must apply class=\"app-root\" to its root element"
+    );
+}

--- a/server/tests/css_design_system.rs
+++ b/server/tests/css_design_system.rs
@@ -59,10 +59,25 @@ fn test_css_custom_properties_defined_in_root() {
         "--radius-lg",
     ];
 
+    // Extract the :root block content
+    let root_re = regex::Regex::new(r":root\s*\{([^}]+)\}").expect("invalid regex for :root block");
+    let root_block = root_re
+        .captures(&css)
+        .expect("main.css must contain a :root block")
+        .get(1)
+        .expect("failed to extract :root block content")
+        .as_str();
+
     for var in &required_vars {
+        // Verify each variable is declared inside :root as `--<name>:`
+        // Lines in the :root block are indented with leading whitespace, so we
+        // match the variable name followed by optional whitespace and a colon.
+        let pattern = format!(r"{var}\s*:");
         assert!(
-            css.contains(var),
-            "main.css must define CSS custom property `{var}` in :root"
+            regex::Regex::new(&pattern)
+                .expect("invalid regex pattern")
+                .is_match(root_block),
+            "main.css must define CSS custom property `{var}` inside :root"
         );
     }
 }
@@ -71,46 +86,59 @@ fn test_css_custom_properties_defined_in_root() {
 fn test_css_custom_property_values() {
     let css = read_main_css();
 
-    // Spot-check specific values from the issue requirements
-    assert!(
-        css.contains("#111827"),
-        "main.css must set --color-bg-primary to #111827"
-    );
-    assert!(
-        css.contains("#1f2937"),
-        "main.css must set --color-bg-secondary to #1f2937"
-    );
-    assert!(
-        css.contains("#374151"),
-        "main.css must set --color-bg-input to #374151"
-    );
-    assert!(
-        css.contains("#3b82f6"),
-        "main.css must set --color-accent to #3b82f6"
-    );
-    assert!(
-        css.contains("#2563eb"),
-        "main.css must set --color-accent-hover to #2563eb"
-    );
-    assert!(
-        css.contains("#4b5563"),
-        "main.css must set --color-border to #4b5563"
-    );
+    // Verify exact assignments for key colour tokens
+    let value_checks = [
+        (
+            r"--color-bg-primary:\s*#111827",
+            "--color-bg-primary",
+            "#111827",
+        ),
+        (
+            r"--color-bg-secondary:\s*#1f2937",
+            "--color-bg-secondary",
+            "#1f2937",
+        ),
+        (
+            r"--color-bg-input:\s*#374151",
+            "--color-bg-input",
+            "#374151",
+        ),
+        (r"--color-accent:\s*#3b82f6", "--color-accent", "#3b82f6"),
+        (
+            r"--color-accent-hover:\s*#2563eb",
+            "--color-accent-hover",
+            "#2563eb",
+        ),
+        (r"--color-border:\s*#4b5563", "--color-border", "#4b5563"),
+    ];
+
+    for (pattern, var, value) in &value_checks {
+        assert!(
+            regex::Regex::new(pattern)
+                .expect("invalid regex pattern")
+                .is_match(&css),
+            "main.css must set {var} to {value}"
+        );
+    }
 }
 
 #[test]
 fn test_css_dark_theme_default() {
     let css = read_main_css();
 
-    // Verify dark background is set on body/html
+    // Verify dark background is set on html/body using the design token
     assert!(
-        css.contains("background-color") && css.contains("var(--color-bg-primary)"),
-        "Dark theme must be applied as default via background-color referencing --color-bg-primary"
+        regex::Regex::new(r"background-color\s*:\s*var\(--color-bg-primary\)")
+            .expect("invalid regex")
+            .is_match(&css),
+        "Dark theme must apply background-color referencing --color-bg-primary"
     );
 
-    // Verify light text is the default
+    // Verify light text is the default using the design token
     assert!(
-        css.contains("color") && css.contains("var(--color-text-primary)"),
+        regex::Regex::new(r"(?m)color\s*:\s*var\(--color-text-primary\)")
+            .expect("invalid regex")
+            .is_match(&css),
         "Dark theme must use --color-text-primary for default text color"
     );
 }
@@ -121,22 +149,30 @@ fn test_css_dark_theme_default() {
 fn test_css_reset_box_sizing() {
     let css = read_main_css();
     assert!(
-        css.contains("box-sizing") && css.contains("border-box"),
-        "Reset must set box-sizing: border-box"
+        regex::Regex::new(
+            r"\*\s*,\s*\*::before\s*,\s*\*::after\s*\{[^}]*box-sizing\s*:\s*border-box"
+        )
+        .expect("invalid regex")
+        .is_match(&css),
+        "Reset must set box-sizing: border-box on the universal selector"
     );
 }
 
 #[test]
 fn test_css_reset_margin_padding() {
     let css = read_main_css();
-    // Check that margin and padding are reset to 0
+    // Verify margin and padding reset are within the universal selector block
     assert!(
-        css.contains("margin: 0") || css.contains("margin:0"),
-        "Reset must set margin to 0"
+        regex::Regex::new(r"\*\s*,\s*\*::before\s*,\s*\*::after\s*\{[^}]*margin\s*:\s*0")
+            .expect("invalid regex")
+            .is_match(&css),
+        "Reset must set margin to 0 within the universal selector block"
     );
     assert!(
-        css.contains("padding: 0") || css.contains("padding:0"),
-        "Reset must set padding to 0"
+        regex::Regex::new(r"\*\s*,\s*\*::before\s*,\s*\*::after\s*\{[^}]*padding\s*:\s*0")
+            .expect("invalid regex")
+            .is_match(&css),
+        "Reset must set padding to 0 within the universal selector block"
     );
 }
 
@@ -146,8 +182,10 @@ fn test_css_reset_margin_padding() {
 fn test_css_has_app_root_class() {
     let css = read_main_css();
     assert!(
-        css.contains(".app-root"),
-        "main.css must define the .app-root class"
+        regex::Regex::new(r#"\.app-root\s*\{[^}]*display\s*:\s*flex"#)
+            .expect("invalid regex")
+            .is_match(&css),
+        "main.css must define .app-root with display: flex"
     );
 }
 
@@ -155,8 +193,10 @@ fn test_css_has_app_root_class() {
 fn test_css_has_scroll_area_class() {
     let css = read_main_css();
     assert!(
-        css.contains(".scroll-area") || css.contains(".message-list"),
-        "main.css must define a scrollable area utility class for the chat layout"
+        regex::Regex::new(r"\.scroll-area\s*\{[^}]*overflow-y\s*:\s*auto")
+            .expect("invalid regex")
+            .is_match(&css),
+        "main.css must define .scroll-area with overflow-y: auto"
     );
 }
 
@@ -164,8 +204,10 @@ fn test_css_has_scroll_area_class() {
 fn test_css_has_sticky_input_class() {
     let css = read_main_css();
     assert!(
-        css.contains(".sticky-input") || css.contains(".chat-input"),
-        "main.css must define a sticky input utility class for the chat layout"
+        regex::Regex::new(r"\.sticky-input\s*\{[^}]*flex-shrink\s*:\s*0")
+            .expect("invalid regex")
+            .is_match(&css),
+        "main.css must define .sticky-input with flex-shrink: 0"
     );
 }
 
@@ -173,8 +215,10 @@ fn test_css_has_sticky_input_class() {
 fn test_css_has_flex_column_full_class() {
     let css = read_main_css();
     assert!(
-        css.contains(".flex-column-full") || css.contains("flex-direction: column"),
-        "main.css must define a flex-column layout utility"
+        regex::Regex::new(r"\.flex-column-full\s*\{[^}]*flex-direction\s*:\s*column")
+            .expect("invalid regex")
+            .is_match(&css),
+        "main.css must define .flex-column-full with flex-direction: column"
     );
 }
 
@@ -185,8 +229,16 @@ fn test_index_html_references_stylesheet() {
     let html = read_index_html();
 
     assert!(
-        html.contains("data-trunk") && html.contains("stylesheet") && html.contains("main.css"),
-        "index.html must reference main.css via a <link data-trunk rel=\"stylesheet\" .../> tag"
+        regex::Regex::new(r#"<link[^>]*rel="stylesheet"[^>]*href="[^"]*main\.css"[^>]*/>"#)
+            .expect("invalid regex")
+            .is_match(&html),
+        "index.html must contain a <link> tag referencing main.css as a stylesheet"
+    );
+    assert!(
+        regex::Regex::new(r#"<link[^>]*data-trunk[^>]*/>"#)
+            .expect("invalid regex")
+            .is_match(&html),
+        "index.html stylesheet link must have data-trunk attribute"
     );
 }
 
@@ -195,8 +247,10 @@ fn test_index_html_still_has_rust_tag() {
     let html = read_index_html();
 
     assert!(
-        html.contains("data-trunk") && html.contains("data-wasm-cargo"),
-        "index.html must still contain the Trunk Rust/WASM entrypoint tag"
+        regex::Regex::new(r#"<link[^>]*data-wasm-cargo="frontend"[^>]*/>"#)
+            .expect("invalid regex")
+            .is_match(&html),
+        "index.html must still contain the Trunk Rust/WASM entrypoint tag with data-wasm-cargo"
     );
 }
 
@@ -207,7 +261,9 @@ fn test_app_component_uses_app_root_class() {
     let lib_rs = read_app_lib_rs();
 
     assert!(
-        lib_rs.contains("app-root"),
+        regex::Regex::new(r#"class="[^"]*\bapp-root\b[^"]*""#)
+            .expect("invalid regex")
+            .is_match(&lib_rs),
         "Leptos App component must apply class=\"app-root\" to its root element"
     );
 }

--- a/wiki/css-design-system.md
+++ b/wiki/css-design-system.md
@@ -23,11 +23,9 @@ The design system gives the chat interface a **dark theme by default**, with a c
    | What you need | Class to use |
    |---|---|
    | Full-height app shell | `.app-root` |
-   | Scrollable message area | `.scroll-area` or `.message-list` |
+   | Full-height flex column | `.flex-column-full` |
+   | Scrollable message area | `.scroll-area` |
    | Sticky bottom input bar | `.sticky-input` |
-   | Chat input row | `.chat-input` |
-   | User message bubble | `.message-bubble .message-bubble--user` |
-   | Assistant message bubble | `.message-bubble .message-bubble--assistant` |
    | Visually hidden but accessible text | `.sr-only` |
 
 3. **Adding new styles**: Create new classes in `frontend/style/main.css` (or a new `.css` file added to `index.html`).

--- a/wiki/css-design-system.md
+++ b/wiki/css-design-system.md
@@ -1,0 +1,75 @@
+# CSS Design System
+
+## Feature Overview
+
+LibreChat uses a **traditional CSS design system** — no Tailwind, no CSS-in-JS, no preprocessors. All visual styles are defined in plain `.css` files under `frontend/style/`, and the build tool (Trunk) bundles them into the final WASM output.
+
+The design system gives the chat interface a **dark theme by default**, with a consistent set of colours, fonts, spacing values, and ready-made utility classes. Every UI component built in future issues should use these design tokens instead of hardcoding values.
+
+### Why does this exist?
+
+- A consistent look and feel across the entire app, built once and reused everywhere.
+- Zero JavaScript overhead for styling — styles are static assets, perfect for resource-constrained devices (Raspberry Pi, old laptops).
+- Easy to audit and modify — just edit a `.css` file, no build step required for style changes.
+
+## User Guide
+
+### For developers: using the design system
+
+1. **Always use CSS custom properties** (e.g., `var(--color-accent)`) instead of raw hex values. This keeps the UI consistent and makes future theming easy.
+
+2. **Use the layout utility classes** for common patterns:
+
+   | What you need | Class to use |
+   |---|---|
+   | Full-height app shell | `.app-root` |
+   | Scrollable message area | `.scroll-area` or `.message-list` |
+   | Sticky bottom input bar | `.sticky-input` |
+   | Chat input row | `.chat-input` |
+   | User message bubble | `.message-bubble .message-bubble--user` |
+   | Assistant message bubble | `.message-bubble .message-bubble--assistant` |
+   | Visually hidden but accessible text | `.sr-only` |
+
+3. **Adding new styles**: Create new classes in `frontend/style/main.css` (or a new `.css` file added to `index.html`).
+
+4. **Previewing changes**: Run `cd frontend && trunk serve` to see the styled page in a browser.
+
+### For reviewers: what to check
+
+- No Tailwind or CSS framework imports.
+- All colours reference `var(--color-*)` tokens.
+- New layout patterns reuse existing utility classes before creating new ones.
+
+## Glossary
+
+| Term | Meaning |
+|---|---|
+| **CSS Custom Property** | A variable in CSS defined with `--name: value;` and used with `var(--name)`. Also called "CSS variable". |
+| **Design Token** | A named value (colour, spacing, font) that defines a visual property of the design system. |
+| **Trunk** | The build tool that compiles Leptos WASM frontends and bundles static assets (CSS, WASM, JS) into a `dist/` folder. |
+| **Reset** | A set of CSS rules that normalise browser defaults (margins, padding, box-sizing) to a consistent baseline. |
+| **Dark Theme** | The default colour scheme with dark backgrounds (`#111827`) and light text (`#f9fafb`). |
+
+## FAQ / Troubleshooting
+
+**Q: Styles aren't showing up after I edit `main.css` — what do I do?**
+
+A: Make sure Trunk is running (`trunk serve`). Trunk watches for file changes and rebuilds automatically. If the issue persists, try a hard refresh (Ctrl+Shift+R) to clear the browser cache.
+
+**Q: Can I use Tailwind or another CSS framework?**
+
+A: No — this project intentionally uses traditional CSS stylesheets for minimal overhead and no build-time JS dependencies.
+
+**Q: Where do I add a new colour or spacing value?**
+
+A: Add it as a CSS custom property in `:root` inside `frontend/style/main.css`, then reference it with `var(--your-new-token)` wherever needed.
+
+**Q: How do I add a new stylesheet file?**
+
+A: Create the `.css` file under `frontend/style/`, then add a `<link data-trunk rel="stylesheet" href="style/your-file.css"/>` tag in `frontend/index.html`.
+
+## Related Resources
+
+- [Trunk documentation](https://trunkrs.dev/) — build tool for Leptos WASM apps
+- [Leptos documentation](https://leptos.dev/) — Rust full-stack WASM framework
+- [Issue #2 on GitHub](https://github.com/BhavsarDevansh/librechat/issues/2) — the original issue for this feature


### PR DESCRIPTION
## Summary

Set up traditional CSS stylesheets and a design system for the Leptos CSR frontend, so all subsequent UI issues can use consistent styling tokens and layout utilities.

Closes #2

## Changes

- **`frontend/style/main.css`** — Global stylesheet with:
  - CSS custom properties (design tokens) for colours, typography, spacing, radii, shadows, and transitions
  - Base reset (box-sizing, margin/padding, font setup, dark theme defaults)
  - Layout utility classes: `.app-root`, `.flex-column-full`, `.scroll-area`, `.sticky-input`, `.sr-only`
  - Webkit scrollbar styling
- **`frontend/index.html`** — Added `<link data-trunk rel="stylesheet" href="style/main.css"/>` so Trunk bundles the stylesheet
- **`frontend/src/lib.rs`** — Wrapped root element in `<div class="app-root">` 
- **`server/tests/css_design_system.rs`** — 13 integration tests verifying all acceptance criteria
- **`docs/css-design-system.md`** — Technical documentation (architecture, tokens, utilities, testing guide)
- **`wiki/css-design-system.md`** — Feature wiki (overview, developer guide, glossary, FAQ)
- Version bumped to 0.2.0 per SemVer

## Acceptance Criteria

- [x] `trunk serve` applies styles from `main.css` correctly
- [x] CSS custom properties are defined in `:root`
- [x] Dark theme is applied by default
- [x] `index.html` references the stylesheet via Trunk link tag
- [x] Base reset and layout utility classes are present

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a CSS design system with tokens (colours, typography, spacing, radii), reusable layout utilities and a default dark theme; app container adopts the design-system layout class and the frontend loads the bundled stylesheet.

* **Documentation**
  * New design system docs and wiki with implementation and reviewer guidance.

* **Tests**
  * Added integration tests validating stylesheet presence, tokens, resets and layout classes.

* **Chores**
  * Bumped frontend and server package versions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->