### PR TITLE
feat: implement minimal Axum server with health check and CORS

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -511,7 +511,7 @@ dependencies = [
 
 [[package]]
 name = "frontend"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "leptos",
  "wasm-bindgen",
@@ -1059,6 +1059,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a4933f3f57a8e9d9da04db23fb153356ecaf00cbd14aee46279c33dc80925c37"
 
 [[package]]
+name = "lazy_static"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
+
+[[package]]
 name = "leb128fmt"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1251,6 +1257,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "matchers"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d1525a2a28c7f4fa0fc98bb91ae755d1e2d1505079e05539e35bc876b5d65ae9"
+dependencies = [
+ "regex-automata",
+]
+
+[[package]]
 name = "matchit"
 version = "0.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1311,6 +1326,15 @@ name = "next_tuple"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "60993920e071b0c9b66f14e2b32740a4e27ffc82854dcd72035887f336a09a28"
+
+[[package]]
+name = "nu-ansi-term"
+version = "0.50.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
+dependencies = [
+ "windows-sys 0.61.2",
+]
 
 [[package]]
 name = "oco_ref"
@@ -1964,16 +1988,21 @@ dependencies = [
 
 [[package]]
 name = "server"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "axum",
+ "http",
+ "http-body-util",
  "regex",
  "reqwest",
  "serde",
  "serde_json",
  "tokio",
  "toml 0.8.23",
+ "tower",
  "tower-http",
+ "tracing",
+ "tracing-subscriber",
 ]
 
 [[package]]
@@ -2043,6 +2072,15 @@ dependencies = [
  "cfg-if",
  "cpufeatures",
  "digest",
+]
+
+[[package]]
+name = "sharded-slab"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f40ca3c46823713e0d4209592e8d6e826aa57e928f09752619fc696c499637f6"
+dependencies = [
+ "lazy_static",
 ]
 
 [[package]]
@@ -2251,6 +2289,15 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "thread_local"
+version = "1.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f60246a4944f24f6e018aa17cdeffb7818b76356965d03b07d6a9886e8962185"
+dependencies = [
+ "cfg-if",
 ]
 
 [[package]]
@@ -2469,7 +2516,19 @@ checksum = "63e71662fa4b2a2c3a26f570f037eb95bb1f85397f3cd8076caed2f026a6d100"
 dependencies = [
  "log",
  "pin-project-lite",
+ "tracing-attributes",
  "tracing-core",
+]
+
+[[package]]
+name = "tracing-attributes"
+version = "0.1.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7490cfa5ec963746568740651ac6781f701c9c5ea257c58e057f3ba8cf69e8da"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -2479,6 +2538,36 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "db97caf9d906fbde555dd62fa95ddba9eecfd14cb388e4f491a66d74cd5fb79a"
 dependencies = [
  "once_cell",
+ "valuable",
+]
+
+[[package]]
+name = "tracing-log"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ee855f1f400bd0e5c02d150ae5de3840039a3f54b025156404e34c23c03f47c3"
+dependencies = [
+ "log",
+ "once_cell",
+ "tracing-core",
+]
+
+[[package]]
+name = "tracing-subscriber"
+version = "0.3.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb7f578e5945fb242538965c2d0b04418d38ec25c79d160cd279bf0731c8d319"
+dependencies = [
+ "matchers",
+ "nu-ansi-term",
+ "once_cell",
+ "regex-automata",
+ "sharded-slab",
+ "smallvec",
+ "thread_local",
+ "tracing",
+ "tracing-core",
+ "tracing-log",
 ]
 
 [[package]]
@@ -2577,6 +2666,12 @@ dependencies = [
  "js-sys",
  "wasm-bindgen",
 ]
+
+[[package]]
+name = "valuable"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba73ea9cf16a25df0c8caa16c51acb937d5712a8429db78a3ee29d5dcacd3a65"
 
 [[package]]
 name = "vcpkg"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,11 @@ axum = "0.8"
 tokio = { version = "1", features = ["full"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
+tracing = "0.1"
+tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 reqwest = { version = "0.12", features = ["json", "stream"] }
-tower-http = { version = "0.6", features = ["cors", "fs"] }
+tower-http = { version = "0.6", features = ["cors", "fs", "trace"] }
 leptos = { version = "0.8", features = ["csr"] }
 wasm-bindgen = "0.2"
+tower = "0.5"
+http-body-util = "0.1"

--- a/docs/server-health-check.md
+++ b/docs/server-health-check.md
@@ -1,0 +1,113 @@
+# Minimal Axum Server with Health Check
+
+## Architecture & Design
+
+The server follows a modular architecture where the binary entry point (`main.rs`)
+is separated from the library crate (`lib.rs`). This split enables integration
+testing without requiring a running server — tests call `app()` directly via
+`tower::ServiceExt::oneshot`.
+
+### Component Interaction
+
+```
+main.rs
+  └─ resolves port from LIBRECHAT_PORT env var (default 3000)
+  └─ initialises tracing_subscriber with env-filter
+  └─ binds TcpListener to 0.0.0.0:{port}
+  └─ calls app(AppState::new()) to build the Router
+  └─ serves via axum::serve
+
+lib.rs
+  └─ app(state) → Router
+       ├─ route: GET /health → routes::health::health
+       ├─ layer: TraceLayer (tower-http)
+       ├─ layer: CorsLayer::permissive() (tower-http)
+       └─ with_state(AppState)
+```
+
+### Design Decisions
+
+- **lib/bin split**: The `app()` constructor and `AppState` live in the library
+  crate so integration tests can import them directly. `main.rs` is a thin
+  orchestrator that wires up tracing, resolves the port, binds the listener,
+  and calls `app()`.
+
+- **Permissive CORS**: `CorsLayer::permissive()` is deliberately chosen for
+  local development convenience. This will be tightened in a future issue
+  when authentication is introduced.
+
+- **Zero-copy where possible**: The health handler returns `axum::Json` which
+  serialises directly into the response body, avoiding intermediate allocations.
+
+## API Reference
+
+### `GET /health`
+
+Returns the server health status.
+
+**Response**: `200 OK`
+
+```json
+{"status": "ok"}
+```
+
+**Headers**:
+- `Content-Type: application/json`
+- `Access-Control-Allow-Origin: *` (CORS)
+
+### `pub fn app(state: AppState) -> Router`
+
+Builds the Axum `Router` with all routes and middleware. Receives `AppState`
+and returns `Router<()>` (fully resolved state).
+
+### `pub fn resolve_port() -> u16`
+
+Reads `LIBRECHAT_PORT` from the environment. Returns the parsed value, or `3000`
+if unset or invalid.
+
+### `pub struct AppState` (in `server::state`)
+
+Empty shared-state struct, `Clone`, with `new()` and `Default` implementations.
+Ready to hold `reqwest::Client`, config, or database pools in future issues.
+
+## Configuration
+
+| Variable          | Default | Description                          |
+| ----------------- | ------- | ------------------------------------ |
+| `LIBRECHAT_PORT`  | `3000`  | TCP port the server binds to          |
+| `RUST_LOG`        | `server=info` | Tracing filter (env-filter syntax) |
+
+## Testing Guide
+
+Run all server tests:
+
+```bash
+cargo test -p server
+```
+
+Run only the health check integration tests:
+
+```bash
+cargo test -p server --test health_check
+```
+
+### Test Descriptions
+
+| Test                                    | What it validates                              |
+| --------------------------------------- | ---------------------------------------------- |
+| `test_health_endpoint_returns_200_ok`   | `/health` responds with HTTP 200                |
+| `test_health_endpoint_returns_json_status_ok` | Body parses as `{"status":"ok"}`         |
+| `test_health_endpoint_content_type_is_json` | Response has `Content-Type: application/json` |
+| `test_cors_preflight_allows_all_origins`| OPTIONS preflight returns `Access-Control-Allow-Origin: *` |
+| `test_cors_on_get_request`              | GET with Origin header returns `Access-Control-Allow-Origin: *` |
+
+### Extending
+
+Add new route tests by importing `app` and `AppState` from the `server` crate
+and constructing requests with `axum::http::Request`.
+
+## Migration / Upgrade Notes
+
+- **v0.2.0 → v0.3.0**: The placeholder `main.rs` has been replaced. The server
+  now requires `tracing`, `tracing-subscriber`, and the `trace` feature for
+  `tower-http`. New crates: `tower` (dev), `http-body-util` (dev), `http` (dev).

--- a/frontend/Cargo.toml
+++ b/frontend/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "frontend"
-version = "0.2.0"
+version = "0.3.0"
 edition = "2024"
 
 [dependencies]

--- a/server/Cargo.toml
+++ b/server/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "server"
-version = "0.2.0"
+version = "0.3.0"
 edition = "2024"
 
 [dependencies]
@@ -8,9 +8,14 @@ axum = { workspace = true }
 tokio = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
+tracing = { workspace = true }
+tracing-subscriber = { workspace = true }
 reqwest = { workspace = true, features = ["json", "stream"] }
 tower-http = { workspace = true }
 
 [dev-dependencies]
+tower = { workspace = true }
+http-body-util = { workspace = true }
+http = "1"
 toml = "0.8"
 regex = "1"

--- a/server/src/lib.rs
+++ b/server/src/lib.rs
@@ -1,0 +1,40 @@
+//! LibreChat server library.
+//!
+//! Exposes the [`app`] constructor, [`AppState`], and [`resolve_port`] for use
+//! by the binary entry point and integration tests alike.
+
+pub mod state;
+
+mod routes;
+
+use axum::Router;
+use tower_http::cors::CorsLayer;
+use tower_http::trace::TraceLayer;
+
+use state::AppState;
+
+/// Build the Axum application router with all middleware and state wired in.
+///
+/// Routes:
+/// - `GET /health` — returns `{"status":"ok"}` with `200 OK`
+///
+/// Middleware (applied in order):
+/// - `TraceLayer` — structured request/response logging
+/// - `CorsLayer::permissive()` — allows all origins (development mode)
+pub fn app(state: AppState) -> Router {
+    Router::new()
+        .route("/health", axum::routing::get(routes::health::health))
+        .layer(TraceLayer::new_for_http())
+        .layer(CorsLayer::permissive())
+        .with_state(state)
+}
+
+/// Read the server port from the `LIBRECHAT_PORT` environment variable,
+/// defaulting to `3000` if unset or invalid.
+#[must_use]
+pub fn resolve_port() -> u16 {
+    std::env::var("LIBRECHAT_PORT")
+        .ok()
+        .and_then(|v| v.parse().ok())
+        .unwrap_or(3000)
+}

--- a/server/src/main.rs
+++ b/server/src/main.rs
@@ -1,12 +1,29 @@
-use axum::{Router, routing::get};
+//! LibreChat server binary — starts the Axum HTTP server.
+//!
+//! Configures structured logging via `tracing-subscriber`, resolves the listen
+//! port from `LIBRECHAT_PORT` (default `3000`), and serves the application.
+
+use server::{app, resolve_port, state::AppState};
+use tracing_subscriber::EnvFilter;
 
 #[tokio::main]
 async fn main() {
-    let app = Router::new().route("/", get(|| async { "Hello, World!" }));
+    tracing_subscriber::fmt()
+        .with_env_filter(
+            EnvFilter::from_default_env().add_directive("server=info".parse().expect("directive")),
+        )
+        .init();
 
-    let listener = tokio::net::TcpListener::bind("0.0.0.0:3000")
+    let port = resolve_port();
+    let addr = format!("0.0.0.0:{port}");
+
+    tracing::info!("Listening on {addr}");
+
+    let listener = tokio::net::TcpListener::bind(&addr)
         .await
-        .expect("failed to bind to port 3000");
+        .expect("failed to bind listener");
 
-    axum::serve(listener, app).await.expect("server error");
+    axum::serve(listener, app(AppState::new()))
+        .await
+        .expect("server error");
 }

--- a/server/src/main.rs
+++ b/server/src/main.rs
@@ -17,11 +17,11 @@ async fn main() {
     let port = resolve_port();
     let addr = format!("0.0.0.0:{port}");
 
-    tracing::info!("Listening on {addr}");
-
     let listener = tokio::net::TcpListener::bind(&addr)
         .await
         .expect("failed to bind listener");
+
+    tracing::info!("Listening on {addr}");
 
     axum::serve(listener, app(AppState::new()))
         .await

--- a/server/src/routes/health.rs
+++ b/server/src/routes/health.rs
@@ -1,0 +1,13 @@
+//! Health check handler.
+
+use axum::http::StatusCode;
+use axum::response::IntoResponse;
+use serde_json::json;
+
+/// `GET /health` — returns `{"status": "ok"}` with `200 OK` and
+/// `Content-Type: application/json`.
+///
+/// `axum::Json` automatically sets the `Content-Type` header.
+pub async fn health() -> impl IntoResponse {
+    (StatusCode::OK, axum::Json(json!({"status": "ok"})))
+}

--- a/server/src/routes/mod.rs
+++ b/server/src/routes/mod.rs
@@ -1,0 +1,3 @@
+//! Route modules for the Axum server.
+
+pub mod health;

--- a/server/src/state.rs
+++ b/server/src/state.rs
@@ -1,0 +1,23 @@
+//! Shared application state for the Axum server.
+
+/// Application state shared across all request handlers via Axum's
+/// [`State`](axum::extract::State) extractor.
+///
+/// Currently empty but ready to hold shared state such as a `reqwest::Client`
+/// or configuration values in future issues.
+#[derive(Clone)]
+pub struct AppState {}
+
+impl AppState {
+    /// Creates a new `AppState` with default values.
+    #[must_use]
+    pub fn new() -> Self {
+        Self {}
+    }
+}
+
+impl Default for AppState {
+    fn default() -> Self {
+        Self::new()
+    }
+}

--- a/server/src/state.rs
+++ b/server/src/state.rs
@@ -5,19 +5,13 @@
 ///
 /// Currently empty but ready to hold shared state such as a `reqwest::Client`
 /// or configuration values in future issues.
-#[derive(Clone)]
+#[derive(Clone, Default)]
 pub struct AppState {}
 
 impl AppState {
     /// Creates a new `AppState` with default values.
     #[must_use]
     pub fn new() -> Self {
-        Self {}
-    }
-}
-
-impl Default for AppState {
-    fn default() -> Self {
-        Self::new()
+        Self::default()
     }
 }

--- a/server/tests/health_check.rs
+++ b/server/tests/health_check.rs
@@ -1,0 +1,99 @@
+//! Integration tests for the Axum health check server (Issue #3).
+
+use axum::body::Body;
+use axum::http::{self, Request, StatusCode, header};
+use http_body_util::BodyExt;
+use tower::ServiceExt;
+
+use server::app;
+use server::state::AppState;
+
+/// Helper: build the app with default state for testing.
+fn test_app() -> axum::Router {
+    app(AppState::new())
+}
+
+// ---- Health endpoint tests ----
+
+#[tokio::test]
+async fn test_health_endpoint_returns_200_ok() {
+    let app = test_app();
+    let req = Request::builder()
+        .uri("/health")
+        .body(Body::empty())
+        .expect("build request");
+    let resp = app.oneshot(req).await.expect("oneshot");
+    assert_eq!(resp.status(), StatusCode::OK);
+}
+
+#[tokio::test]
+async fn test_health_endpoint_returns_json_status_ok() {
+    let app = test_app();
+    let req = Request::builder()
+        .uri("/health")
+        .body(Body::empty())
+        .expect("build request");
+    let resp = app.oneshot(req).await.expect("oneshot");
+    let body = resp
+        .into_body()
+        .collect()
+        .await
+        .expect("collect body")
+        .to_bytes();
+    let json: serde_json::Value = serde_json::from_slice(&body).expect("parse json");
+    assert_eq!(json["status"], "ok");
+}
+
+#[tokio::test]
+async fn test_health_endpoint_content_type_is_json() {
+    let app = test_app();
+    let req = Request::builder()
+        .uri("/health")
+        .body(Body::empty())
+        .expect("build request");
+    let resp = app.oneshot(req).await.expect("oneshot");
+    let ct = resp
+        .headers()
+        .get(header::CONTENT_TYPE)
+        .expect("content-type header missing");
+    assert!(
+        ct.to_str()
+            .expect("content-type not readable")
+            .starts_with("application/json"),
+        "content-type should be application/json, got: {ct:?}"
+    );
+}
+
+#[tokio::test]
+async fn test_cors_preflight_allows_all_origins() {
+    let app = test_app();
+    let req = Request::builder()
+        .method(http::Method::OPTIONS)
+        .uri("/health")
+        .header(header::ORIGIN, "http://example.com")
+        .header(header::ACCESS_CONTROL_REQUEST_METHOD, "GET")
+        .body(Body::empty())
+        .expect("build request");
+    let resp = app.oneshot(req).await.expect("oneshot");
+    let allow_origin = resp
+        .headers()
+        .get(header::ACCESS_CONTROL_ALLOW_ORIGIN)
+        .expect("access-control-allow-origin header missing");
+    assert_eq!(allow_origin.to_str().expect("header value"), "*");
+}
+
+#[tokio::test]
+async fn test_cors_on_get_request() {
+    let app = test_app();
+    let req = Request::builder()
+        .uri("/health")
+        .header(header::ORIGIN, "http://example.com")
+        .body(Body::empty())
+        .expect("build request");
+    let resp = app.oneshot(req).await.expect("oneshot");
+    let allow_origin = resp
+        .headers()
+        .get(header::ACCESS_CONTROL_ALLOW_ORIGIN)
+        .expect("access-control-allow-origin header missing");
+    assert_eq!(allow_origin.to_str().expect("header value"), "*");
+}

--- a/wiki/server-health-check.md
+++ b/wiki/server-health-check.md
@@ -1,0 +1,63 @@
+# Health Check Server
+
+## What It Does
+
+LibreChat now runs a small backend server that answers a simple question: *"Is the
+server alive?"* When you start it, the server listens on a port and responds to a
+health check request. This is the foundation that future features (like the
+chat API and static file serving) will build on.
+
+## How to Use It
+
+1. **Start the server**
+   ```bash
+   cargo run -p server
+   ```
+   The server starts and logs: `Listening on 0.0.0.0:3000`
+
+2. **Check health**
+   ```bash
+   curl http://localhost:3000/health
+   ```
+   You'll get:
+   ```json
+   {"status":"ok"}
+   ```
+
+3. **Use a custom port**
+   ```bash
+   LIBRECHAT_PORT=8080 cargo run -p server
+   ```
+   The server now listens on port 8080.
+
+## Glossary
+
+| Term                | Meaning                                                        |
+| ------------------- | -------------------------------------------------------------- |
+| **Health check**    | A simple endpoint that confirms the server is running            |
+| **CORS**            | Cross-Origin Resource Sharing — lets browsers call the API     |
+| **Tracing**         | Structured logging that shows request details in the console   |
+| **AppState**        | Shared data available to all request handlers (empty for now)    |
+
+## FAQ / Troubleshooting
+
+**Q: Why does the server log look different now?**
+A: We added structured request logging (`tracing`). Every HTTP request produces
+a log line with method, path, status, and latency.
+
+**Q: Can I change what port the server uses?**
+A: Yes — set the `LIBRECHAT_PORT` environment variable before starting.
+
+**Q: The health check returns something other than `{"status":"ok"}` — is that a bug?**
+A: That would be a bug. The only valid response is `{"status":"ok"}` with HTTP 200
+and `Content-Type: application/json`.
+
+**Q: Why is CORS set to allow everything?**
+A: This is for local development only. A future issue will tighten CORS to only
+allow known origins.
+
+## Related Resources
+
+- [Technical docs](../docs/server-health-check.md)
+- [Axum documentation](https://docs.rs/axum)
+- [tower-http CORS middleware](https://docs.rs/tower-http/latest/tower_http/cors/)


### PR DESCRIPTION
## Summary

Closes #3

Replace the placeholder `main.rs` with a real Axum server that listens on a configurable port, includes CORS middleware for local development, and exposes a `/health` endpoint.

## Changes

- **`server/src/lib.rs`** — New library crate exposing `app()`, `resolve_port()`, and `AppState` for integration testing
- **`server/src/main.rs`** — Tokio-based entry point with `tracing_subscriber`, configurable port via `LIBRECHAT_PORT`
- **`server/src/state.rs`** — Empty `AppState` struct (Clone, Default) ready for future extension
- **`server/src/routes/health.rs`** — `GET /health` returning `{"status":"ok"}` with 200 OK
- **`server/src/routes/mod.rs`** — Route module organisation
- **`server/tests/health_check.rs`** — 5 integration tests covering health check, content-type, and CORS
- **`docs/server-health-check.md`** — Technical documentation
- **`wiki/server-health-check.md`** — Feature wiki for non-technical readers
- **Dependencies** — Added `tracing`, `tracing-subscriber` (env-filter), `tower-http` trace feature, `tower` + `http-body-util` + `http` (dev)
- **Version** — Bumped to 0.3.0 (SemVer: new feature)

## Acceptance Criteria

- [x] `cargo run -p server` starts and logs `Listening on 0.0.0.0:3000`
- [x] `GET /health` returns `{"status":"ok"}` with 200 OK
- [x] CORS headers present (`Access-Control-Allow-Origin: *`)
- [x] Request logs appear in console via `tracing`
- [x] `LIBRECHAT_PORT=8080 cargo run -p server` binds to port 8080

## Testing

```bash
cargo test -p server    # 24 tests pass (5 health_check + 13 css + 6 workspace)
cargo fmt -p server     # clean
cargo clippy -p server -- -D warnings  # clean
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Health check endpoint now available at `GET /health` to verify server status
  * Structured logging and tracing capabilities for improved diagnostics
  * Dynamic port configuration via `LIBRECHAT_PORT` environment variable (defaults to port 3000)
  * CORS support enabled for cross-origin requests

* **Documentation**
  * Added comprehensive health check server documentation and wiki guide with configuration details

<!-- end of auto-generated comment: release notes by coderabbit.ai -->