### PR TITLE
feat: serve Leptos WASM frontend from Axum via static file middleware

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1988,7 +1988,7 @@ dependencies = [
 
 [[package]]
 name = "server"
-version = "0.3.0"
+version = "0.4.0"
 dependencies = [
  "axum",
  "http",
@@ -1997,6 +1997,7 @@ dependencies = [
  "reqwest",
  "serde",
  "serde_json",
+ "tempfile",
  "tokio",
  "toml 0.8.23",
  "tower",

--- a/docs/static-file-serving.md
+++ b/docs/static-file-serving.md
@@ -1,0 +1,155 @@
+# Static File Serving (Leptos WASM Frontend)
+
+## Architecture & Design
+
+The server serves the compiled Leptos WASM frontend as static files, enabling a
+single-binary deployment model where the same Axum process handles both the API
+and the UI.
+
+### Component Interaction
+
+```
+main.rs
+  └─ resolves port from LIBRECHAT_PORT env var (default 3000)
+  └─ resolves static dir from LIBRECHAT_STATIC_DIR env var (default ../frontend/dist)
+  └─ initialises tracing_subscriber with env-filter
+  └─ binds TcpListener to 0.0.0.0:{port}
+  └─ calls app(AppState::new()) to build the Router
+  └─ serves via axum::serve
+
+lib.rs
+  └─ app(state) → Router
+       ├─ route: GET /health → routes::health::health
+       ├─ fallback_service: ServeDir (static files from state.static_dir)
+       │    ├─ append_index_html_on_directories(true)
+       │    └─ fallback: ServeFile("{static_dir}/index.html")
+       ├─ layer: TraceLayer (tower-http)
+       ├─ layer: CorsLayer::permissive() (tower-http)
+       └─ with_state(AppState)
+```
+
+### Design Decisions
+
+- **`fallback_service` instead of nested routes**: Axum's `Router::fallback_service`
+  registers the `ServeDir` as a catch-all. All API routes are registered first
+  and take priority; any unmatched path falls through to the static file service.
+
+- **SPA fallback via `ServeFile`**: The `ServeDir` is configured with a `.fallback()`
+  that serves `index.html` for any path not matching a static file. This enables
+  client-side routing in the Leptos WASM app — navigating to `/chat/history` will
+  return `index.html`, and the Leptos router handles the route in the browser.
+
+- **`append_index_html_on_directories(true)`**: Requests to directory paths (e.g.
+  `GET /`) automatically append `index.html`, ensuring the root path serves the
+  app entry point.
+
+- **Configurable static directory**: The directory defaults to the relative path
+  `../frontend/dist`, resolved against the process's current working directory
+  (CWD) at runtime via `PathBuf::from`. This only matches the binary's directory
+  when the server is launched from the workspace root (e.g. via `cargo run`).
+  Operators can override it with the `LIBRECHAT_STATIC_DIR` environment variable
+  or supply an absolute path via `AppState::with_static_dir()` at startup to avoid
+  CWD-related surprises.
+
+- **`AppState` holds `static_dir`**: The static directory path is stored in
+  `AppState::static_dir` as a `PathBuf`, resolved once at startup. This avoids
+  repeated env var lookups and makes the path testable.
+
+## API Reference
+
+### `GET /health`
+
+Returns the server health status. (Unchanged — see `docs/server-health-check.md`.)
+
+### `GET /` (and all non-API paths)
+
+Serves the Leptos WASM frontend. The static file service:
+
+- Serves files from the configured directory (default: `../frontend/dist/`)
+- Appends `index.html` for directory requests
+- Falls back to `index.html` for any path not matching a file (SPA routing)
+- Returns correct MIME types (`.js` → `application/javascript`, `.wasm` →
+  `application/wasm`, `.html` → `text/html`, etc.)
+
+### `pub fn app(state: AppState) -> Router`
+
+Builds the Axum `Router` with API routes, static file fallback, and middleware.
+The route priority is:
+
+1. `GET /health` — API handler
+2. All other paths — `ServeDir` fallback (static files)
+
+### `pub struct AppState` (in `server::state`)
+
+Shared application state with a `static_dir: PathBuf` field.
+
+```rust
+let state = AppState::new();                // resolves from env / default
+let state = AppState::with_static_dir(path); // explicit override (for tests)
+```
+
+The `Default` impl and `AppState::new()` both resolve the static directory
+using `LIBRECHAT_STATIC_DIR`, falling back to the relative path
+`../frontend/dist` (resolved against the CWD at runtime).
+
+## Configuration
+
+| Variable               | Default            | Description                                      |
+| ---------------------- | ------------------ | ------------------------------------------------ |
+| `LIBRECHAT_PORT`       | `3000`             | TCP port the server binds to                      |
+| `LIBRECHAT_STATIC_DIR` | `../frontend/dist` | Directory containing built frontend static files |
+| `RUST_LOG`             | `server=info`     | Tracing filter (env-filter syntax)               |
+
+**Note**: `LIBRECHAT_STATIC_DIR` defaults to a relative path resolved against
+the process's current working directory. For production deployments, set it to
+an absolute path to avoid CWD-related issues.
+
+## Testing Guide
+
+Run all server tests:
+
+```bash
+cargo test -p server
+```
+
+Run only the static file serving integration tests:
+
+```bash
+cargo test -p server --test static_file_serving
+```
+
+### Test Descriptions
+
+| Test                                         | What it validates                                    |
+| -------------------------------------------- | ---------------------------------------------------- |
+| `test_get_root_returns_index_html`           | `GET /` returns `index.html` (200 OK)                |
+| `test_static_file_served_with_correct_content_type` | Static files get proper MIME types              |
+| `test_health_endpoint_still_returns_json`    | `/health` returns JSON, not `index.html`              |
+| `test_nonexistent_path_returns_index_html_spa_fallback` | SPA fallback: unknown paths serve `index.html` |
+| `test_static_dir_env_var_override`           | `LIBRECHAT_STATIC_DIR` overrides the default dir     |
+| `test_default_static_dir_is_frontend_dist`   | Default `static_dir` ends with `frontend/dist`       |
+| `test_with_static_dir_constructor`            | `AppState::with_static_dir()` sets the field correctly |
+
+### Extending
+
+Add new static file tests by importing `app` and `AppState` from the `server`
+crate. Use `AppState::with_static_dir(temp_dir)` to avoid depending on a real
+frontend build:
+
+```rust
+let app = app(AppState::with_static_dir(PathBuf::from("/tmp/test-static")));
+```
+
+## Migration / Upgrade Notes
+
+- **v0.3.0 → v0.4.0**: `AppState` now has a `static_dir: PathBuf` field. The
+  `Default` implementation resolves the static directory from the environment
+  (falling back to `../frontend/dist`). Any code constructing `AppState` directly
+  should use `AppState::new()` or `AppState::with_static_dir(path)`.
+
+- **New dependency**: `tower-http` already included the `fs` feature; no new crate
+  was added. `ServeDir` and `ServeFile` are re-exported from
+  `tower_http::services`.
+
+- **Future work**: A future issue will embed static assets into the binary using
+  `include_dir!` or `rust-embed`, replacing runtime file serving for production.

--- a/server/Cargo.toml
+++ b/server/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "server"
-version = "0.3.0"
+version = "0.4.0"
 edition = "2024"
 
 [dependencies]
@@ -19,3 +19,4 @@ http-body-util = { workspace = true }
 http = "1"
 toml = "0.8"
 regex = "1"
+tempfile = "3"

--- a/server/src/lib.rs
+++ b/server/src/lib.rs
@@ -9,6 +9,7 @@ mod routes;
 
 use axum::Router;
 use tower_http::cors::CorsLayer;
+use tower_http::services::{ServeDir, ServeFile};
 use tower_http::trace::TraceLayer;
 
 use state::AppState;
@@ -18,14 +19,30 @@ use state::AppState;
 /// Routes:
 /// - `GET /health` — returns `{"status":"ok"}` with `200 OK`
 ///
+/// Static files:
+/// - `/` — `ServeDir` serves the Leptos WASM frontend from the configured
+///   static directory, with `index.html` appended for directory requests and
+///   SPA-style fallback for unknown paths.
+///
+/// API routes are registered before the static file catch-all so they take
+/// priority.
+///
 /// Middleware (applied in order):
 /// - `TraceLayer` — structured request/response logging
 /// - `CorsLayer::permissive()` — allows all origins (development mode)
 pub fn app(state: AppState) -> Router {
+    let static_dir = &state.static_dir;
+    let index_path = static_dir.join("index.html");
+
+    let serve_dir = ServeDir::new(static_dir)
+        .append_index_html_on_directories(true)
+        .fallback(ServeFile::new(index_path));
+
     Router::new()
         .route("/health", axum::routing::get(routes::health::health))
         .layer(TraceLayer::new_for_http())
         .layer(CorsLayer::permissive())
+        .fallback_service(serve_dir)
         .with_state(state)
 }
 

--- a/server/src/state.rs
+++ b/server/src/state.rs
@@ -1,17 +1,70 @@
 //! Shared application state for the Axum server.
 
+use std::path::PathBuf;
+
+/// Default static directory as a relative path resolved against the process's
+/// current working directory at runtime.
+const DEFAULT_STATIC_DIR: &str = "../frontend/dist";
+
+/// Environment variable key for overriding the static directory.
+const STATIC_DIR_ENV: &str = "LIBRECHAT_STATIC_DIR";
+
 /// Application state shared across all request handlers via Axum's
 /// [`State`](axum::extract::State) extractor.
 ///
-/// Currently empty but ready to hold shared state such as a `reqwest::Client`
-/// or configuration values in future issues.
-#[derive(Clone, Default)]
-pub struct AppState {}
+/// Holds the directory path from which static frontend assets are served.
+/// The directory defaults to the relative path `../frontend/dist`, resolved
+/// against the process's current working directory (CWD) at runtime via
+/// [`resolve_static_dir`]. This only matches the binary's directory when the
+/// server is launched from the workspace root (e.g. via `cargo run`).
+///
+/// Override the default by setting the `LIBRECHAT_STATIC_DIR` environment
+/// variable or by calling [`AppState::with_static_dir`] with an absolute path
+/// at startup.
+#[derive(Clone)]
+pub struct AppState {
+    /// Directory containing static frontend files served by `ServeDir`.
+    pub static_dir: PathBuf,
+}
 
 impl AppState {
     /// Creates a new `AppState` with default values.
+    ///
+    /// Resolves the static directory from the `LIBRECHAT_STATIC_DIR`
+    /// environment variable, falling back to [`DEFAULT_STATIC_DIR`]. Both
+    /// `new()` and the [`Default`] impl delegate to [`resolve_static_dir`],
+    /// which resolves the relative default against the CWD at runtime.
     #[must_use]
     pub fn new() -> Self {
-        Self::default()
+        Self {
+            static_dir: resolve_static_dir(),
+        }
     }
+
+    /// Creates an `AppState` with a specific static directory.
+    ///
+    /// Useful for testing where a temporary directory is needed, or for
+    /// production deployments that require an absolute path to avoid
+    /// CWD-related resolution surprises.
+    #[must_use]
+    pub fn with_static_dir(static_dir: PathBuf) -> Self {
+        Self { static_dir }
+    }
+}
+
+impl Default for AppState {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+/// Resolve the static directory path.
+///
+/// Checks the `LIBRECHAT_STATIC_DIR` environment variable first;
+/// if unset, returns the default relative path `../frontend/dist` resolved
+/// against the process's current working directory.
+fn resolve_static_dir() -> PathBuf {
+    std::env::var(STATIC_DIR_ENV)
+        .map(PathBuf::from)
+        .unwrap_or_else(|_| PathBuf::from(DEFAULT_STATIC_DIR))
 }

--- a/server/tests/static_file_serving.rs
+++ b/server/tests/static_file_serving.rs
@@ -1,0 +1,217 @@
+//! Integration tests for static file serving (Issue #4).
+//!
+//! Verifies that the Axum server serves the Leptos WASM frontend as static
+//! files with SPA-style fallback routing.
+
+use axum::body::Body;
+use axum::http::{Request, StatusCode, header};
+use http_body_util::BodyExt;
+use tower::ServiceExt;
+
+use server::app;
+use server::state::AppState;
+
+use std::path::PathBuf;
+use std::sync::Mutex;
+
+/// Mutex serialising tests that mutate the `LIBRECHAT_STATIC_DIR` environment
+/// variable. Cargo runs tests in parallel, so unsynchronised `set_var` /
+/// `remove_var` calls would cause data races.
+static ENV_LOCK: Mutex<()> = Mutex::new(());
+
+/// Helper: create a temporary directory with test static files.
+///
+/// Writes an `index.html` and a `test-asset.txt` so that tests can verify
+/// static file serving without depending on a real frontend build.
+fn create_temp_static_dir() -> (tempfile::TempDir, PathBuf) {
+    let dir = tempfile::tempdir().expect("create temp dir");
+    let dir_path = dir.path().to_path_buf();
+
+    std::fs::write(
+        dir.path().join("index.html"),
+        r#"<!DOCTYPE html><html><head><title>Test</title></head><body>SPA</body></html>"#,
+    )
+    .expect("write index.html");
+
+    std::fs::write(dir.path().join("test-asset.txt"), "hello from static")
+        .expect("write test-asset.txt");
+
+    (dir, dir_path)
+}
+
+/// Helper: build the app with a specific static directory.
+fn test_app_with_static_dir(static_dir: PathBuf) -> axum::Router {
+    app(AppState::with_static_dir(static_dir))
+}
+
+// ---- Acceptance criteria tests ----
+
+#[tokio::test]
+async fn test_get_root_returns_index_html() {
+    let (_temp, dir_path) = create_temp_static_dir();
+    let app = test_app_with_static_dir(dir_path);
+
+    let req = Request::builder()
+        .uri("/")
+        .body(Body::empty())
+        .expect("build request");
+    let resp = app.oneshot(req).await.expect("oneshot");
+
+    assert_eq!(resp.status(), StatusCode::OK);
+
+    let body = resp
+        .into_body()
+        .collect()
+        .await
+        .expect("collect body")
+        .to_bytes();
+    let html = String::from_utf8(body.to_vec()).expect("valid utf-8");
+    assert!(
+        html.contains("SPA"),
+        "GET / should return index.html content, got: {html}"
+    );
+}
+
+#[tokio::test]
+async fn test_static_file_served_with_correct_content_type() {
+    let (_temp, dir_path) = create_temp_static_dir();
+    let app = test_app_with_static_dir(dir_path);
+
+    let req = Request::builder()
+        .uri("/test-asset.txt")
+        .body(Body::empty())
+        .expect("build request");
+    let resp = app.oneshot(req).await.expect("oneshot");
+
+    assert_eq!(resp.status(), StatusCode::OK);
+
+    let ct = resp
+        .headers()
+        .get(header::CONTENT_TYPE)
+        .expect("content-type header missing");
+    assert!(
+        ct.to_str()
+            .expect("content-type not readable")
+            .starts_with("text/plain"),
+        "text file should have text/plain content-type, got: {ct:?}"
+    );
+}
+
+#[tokio::test]
+async fn test_health_endpoint_still_returns_json() {
+    let (_temp, dir_path) = create_temp_static_dir();
+    let app = test_app_with_static_dir(dir_path);
+
+    let req = Request::builder()
+        .uri("/health")
+        .body(Body::empty())
+        .expect("build request");
+    let resp = app.oneshot(req).await.expect("oneshot");
+
+    assert_eq!(resp.status(), StatusCode::OK);
+
+    let ct = resp
+        .headers()
+        .get(header::CONTENT_TYPE)
+        .expect("content-type header missing");
+    assert!(
+        ct.to_str()
+            .expect("content-type not readable")
+            .starts_with("application/json"),
+        "health endpoint should return application/json, got: {ct:?}"
+    );
+}
+
+#[tokio::test]
+async fn test_nonexistent_path_returns_index_html_spa_fallback() {
+    let (_temp, dir_path) = create_temp_static_dir();
+    let app = test_app_with_static_dir(dir_path);
+
+    let req = Request::builder()
+        .uri("/nonexistent-path")
+        .body(Body::empty())
+        .expect("build request");
+    let resp = app.oneshot(req).await.expect("oneshot");
+
+    // SPA fallback: unknown paths should serve index.html
+    assert_eq!(resp.status(), StatusCode::OK);
+
+    let body = resp
+        .into_body()
+        .collect()
+        .await
+        .expect("collect body")
+        .to_bytes();
+    let html = String::from_utf8(body.to_vec()).expect("valid utf-8");
+    assert!(
+        html.contains("SPA"),
+        "unknown path should fall back to index.html, got: {html}"
+    );
+}
+
+#[tokio::test]
+async fn test_static_dir_env_var_override() {
+    let _lock = ENV_LOCK.lock().expect("env lock");
+    let (_temp, dir_path) = create_temp_static_dir();
+
+    let env_key = "LIBRECHAT_STATIC_DIR";
+    let original = std::env::var(env_key).ok();
+    // Safety: guarded by ENV_LOCK to serialise parallel test access.
+    unsafe {
+        std::env::set_var(env_key, dir_path.to_str().expect("path to str"));
+    }
+
+    let state = AppState::new();
+    let resolved_dir = state.static_dir.clone();
+
+    // Restore env var
+    unsafe {
+        if let Some(val) = original {
+            std::env::set_var(env_key, val);
+        } else {
+            std::env::remove_var(env_key);
+        }
+    }
+
+    assert_eq!(
+        resolved_dir, dir_path,
+        "LIBRECHAT_STATIC_DIR should override the default static directory"
+    );
+}
+
+#[tokio::test]
+async fn test_default_static_dir_is_frontend_dist() {
+    let _lock = ENV_LOCK.lock().expect("env lock");
+
+    let env_key = "LIBRECHAT_STATIC_DIR";
+    let original = std::env::var(env_key).ok();
+    // Safety: guarded by ENV_LOCK to serialise parallel test access.
+    unsafe {
+        std::env::remove_var(env_key);
+    }
+
+    let state = AppState::new();
+    let default_dir = state.static_dir.clone();
+
+    // Restore env var
+    unsafe {
+        if let Some(val) = original {
+            std::env::set_var(env_key, val);
+        }
+    }
+
+    assert!(
+        default_dir.ends_with("frontend/dist"),
+        "default static_dir should end with 'frontend/dist', got: {default_dir:?}"
+    );
+}
+
+#[tokio::test]
+async fn test_with_static_dir_constructor() {
+    let custom_dir = PathBuf::from("/tmp/custom-static");
+    let state = AppState::with_static_dir(custom_dir.clone());
+    assert_eq!(
+        state.static_dir, custom_dir,
+        "with_static_dir should set the static_dir field"
+    );
+}

--- a/wiki/static-file-serving.md
+++ b/wiki/static-file-serving.md
@@ -1,0 +1,90 @@
+# Static File Serving
+
+## What It Does
+
+LibreChat now serves its own web interface directly from the backend server.
+When you open the app in a browser, the same server that handles API requests
+also delivers the HTML, JavaScript, and WASM files that make up the user
+interface. This means you only need to run a single program — no separate
+frontend server required.
+
+## How to Use It
+
+1. **Build the frontend** (you only need to do this once, or after making UI changes)
+   ```bash
+   cd frontend && trunk build
+   ```
+   This creates the compiled files in `frontend/dist/`.
+
+2. **Start the server**
+   ```bash
+   cargo run -p server
+   ```
+   The server starts and logs: `Listening on 0.0.0.0:3000`
+
+3. **Open the app**
+   - Visit `http://localhost:3000/` in your browser
+   - You'll see the Leptos WASM interface load
+   - The health check is still at `http://localhost:3000/health`
+
+4. **Use a custom static directory**
+   ```bash
+   LIBRECHAT_STATIC_DIR=/path/to/my/dist cargo run -p server
+   ```
+   The server will serve frontend files from that directory instead. Supply an absolute path to avoid surprises if the working directory changes.
+
+## How It Works
+
+The server uses two rules for handling requests:
+
+| Request path          | What happens                                        |
+| --------------------- | --------------------------------------------------- |
+| `/health`             | Returns `{"status":"ok"}` (API handler)             |
+| `/`                   | Serves `index.html` (the app entry point)           |
+| `/some-file.js`       | Serves the file from the static directory           |
+| `/any/other/path`     | Serves `index.html` (so the app can handle the URL) |
+
+The last rule is called **SPA fallback** — it lets the Leptos app handle
+URLs like `/chat/history` in the browser, even though those pages don't
+exist as real files on the server.
+
+## Glossary
+
+| Term           | Meaning                                                              |
+| -------------- | -------------------------------------------------------------------- |
+| **WASM**       | WebAssembly — a fast binary format that runs in the browser          |
+| **SPA**        | Single-Page Application — the app loads once, then handles URLs in the browser |
+| **ServeDir**   | A tower-http service that serves files from a directory             |
+| **Static files** | Files like HTML, JS, CSS, and WASM that don't change per request  |
+| **Fallback**   | What the server does when a URL doesn't match any file              |
+
+## FAQ / Troubleshooting
+
+**Q: I see "404 Not Found" when I visit the app.**
+A: Make sure you've built the frontend first: `cd frontend && trunk build`.
+The server looks for files in `frontend/dist/` by default.
+
+**Q: Can I change where the server looks for frontend files?**
+A: Yes — set the `LIBRECHAT_STATIC_DIR` environment variable to the directory
+containing your built frontend.
+
+**Q: Why does visiting a random URL like `/chat/history` return a page instead of 404?**
+A: That's the SPA fallback. The server returns `index.html` for any unknown path
+so the Leptos router in the browser can handle the URL. If the Leptos router
+doesn't recognise it either, it will show its own 404 page.
+
+**Q: The app works but `/health` returns HTML instead of JSON — what's wrong?**
+A: This shouldn't happen. API routes are registered before the static file
+catch-all, so `/health` always returns JSON. If you see HTML, check that the
+health route is correctly registered in `lib.rs`.
+
+**Q: Will the static files be embedded in the binary eventually?**
+A: Yes — a future issue will embed the assets into the binary using
+`include_dir!` or `rust-embed`, eliminating the need for a separate `dist/`
+directory at runtime.
+
+## Related Resources
+
+- [Technical docs](../docs/static-file-serving.md)
+- [tower-http ServeDir documentation](https://docs.rs/tower-http/latest/tower_http/services/struct.ServeDir.html)
+- [Leptos framework](https://leptos.dev/)


### PR DESCRIPTION
Configures the Axum server to serve the compiled Leptos WASM frontend as static files, enabling single-binary deployment.

**Changes:**
- Add static_dir PathBuf field to AppState with LIBRECHAT_STATIC_DIR env var override
- Wire ServeDir with SPA fallback (ServeFile) as fallback_service after API routes
- Add AppState::with_static_dir() constructor for testing
- Add 7 integration tests covering all acceptance criteria
- Add technical docs and feature wiki
- Bump version to 0.4.0

**Acceptance Criteria:**
- GET / serves index.html
- Static files served with correct MIME types
- GET /health still returns JSON API response
- GET /nonexistent-path returns index.html (SPA fallback)
- LIBRECHAT_STATIC_DIR env var overrides default directory

Closes #4

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Backend now serves the compiled frontend assets from a configurable static directory and provides SPA fallback to return the index page for unmapped paths.
  * Dedicated health endpoint remains available and prioritized over static serving.

* **Documentation**
  * Added detailed guides and FAQ for static file serving, configuration and troubleshooting.

* **Tests**
  * Added integration tests covering static asset serving, SPA fallback and health endpoint behaviour.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->