### PR TITLE
feat: define LlmProvider trait and shared chat types

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1988,8 +1988,9 @@ dependencies = [
 
 [[package]]
 name = "server"
-version = "0.4.0"
+version = "0.5.0"
 dependencies = [
+ "async-trait",
  "axum",
  "http",
  "http-body-util",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,3 +15,4 @@ leptos = { version = "0.8", features = ["csr"] }
 wasm-bindgen = "0.2"
 tower = "0.5"
 http-body-util = "0.1"
+async-trait = "0.1"

--- a/docs/providers.md
+++ b/docs/providers.md
@@ -1,0 +1,133 @@
+# LLM Provider Abstraction Layer
+
+## Architecture & Design
+
+The `providers` module (`server/src/providers/`) defines the core abstraction
+layer for LLM backends. All provider implementations share a single trait
+(`LlmProvider`) and a common set of request/response types, making it
+straightforward to swap or add backends without changing downstream code.
+
+### Data Flow
+
+```
+Client Request
+     │
+     ▼
+Axum Route Handler
+     │
+     ▼
+LlmProvider::chat_completion / chat_completion_stream
+     │
+     ▼
+Provider Implementation (Ollama, OpenAI, …)
+     │
+     ▼
+ChatCompletionResponse | mpsc::Receiver<ChatCompletionChunk>
+```
+
+### Design Decisions
+
+- **OpenAI-compatible types**: `ChatCompletionRequest`, `ChatCompletionResponse`,
+  and `ChatCompletionChunk` mirror the OpenAI Chat Completions API format
+  because both Ollama and OpenAI use it. This avoids format-mapping overhead
+  at the trait boundary.
+- **`mpsc` channel for streaming**: Streaming uses
+  `tokio::sync::mpsc::Receiver` rather than returning a `Stream` directly.
+  This simplifies integration with Axum's SSE handler and avoids requiring
+  consumers to implement `Stream` traits.
+- **`async_trait`**: The `LlmProvider` trait uses `async_trait` to support
+  async methods in the trait object, consistent with the project's Axum-based
+  async architecture.
+
+## API Reference
+
+### Trait: `LlmProvider`
+
+```rust
+#[async_trait]
+pub trait LlmProvider: Send + Sync {
+    async fn chat_completion(
+        &self,
+        request: ChatCompletionRequest,
+    ) -> Result<ChatCompletionResponse, ProviderError>;
+
+    async fn chat_completion_stream(
+        &self,
+        request: ChatCompletionRequest,
+    ) -> Result<
+        tokio::sync::mpsc::Receiver<Result<ChatCompletionChunk, ProviderError>>,
+        ProviderError,
+    >;
+
+    fn name(&self) -> &str;
+}
+```
+
+| Method | Description |
+|--------|-------------|
+| `chat_completion` | Non-streaming request. Returns a full response. |
+| `chat_completion_stream` | Streaming request. Returns a channel receiver that yields chunks. |
+| `name` | Human-readable provider name (e.g. `"Ollama"`, `"OpenAI"`). |
+
+### Shared Types
+
+| Type | Module | Description |
+|------|--------|-------------|
+| `ChatMessage` | `providers::types` | A single message with `role` and `content`. |
+| `MessageRole` | `providers::types` | Enum: `System`, `User`, `Assistant`. Serialized as lowercase. |
+| `ChatCompletionRequest` | `providers::types` | Request body: `model`, `messages`, optional `temperature`/`max_tokens`/`stream`. |
+| `ChatCompletionResponse` | `providers::types` | Non-streaming response: `id`, `model`, `choices`, `usage`. |
+| `Choice` | `providers::types` | A single completion choice with `index`, `message`, `finish_reason`. |
+| `Usage` | `providers::types` | Token usage: `prompt_tokens`, `completion_tokens`, `total_tokens`. |
+| `ChatCompletionChunk` | `providers::types` | A streaming chunk: `id`, `model`, `choices`. |
+| `ChunkChoice` | `providers::types` | A choice within a streaming chunk. |
+| `ChunkDelta` | `providers::types` | Delta content: optional `role` and `content`. |
+
+### Error Type: `ProviderError`
+
+```rust
+pub enum ProviderError {
+    ConnectionFailed(String),
+    ApiError { status: u16, message: String },
+    StreamEnded,
+    InvalidResponse(String),
+}
+```
+
+| Variant | `Display` output |
+|---------|-----------------|
+| `ConnectionFailed(msg)` | `Connection failed: {msg}` |
+| `ApiError { status, message }` | `API error ({status}): {message}` |
+| `StreamEnded` | `Stream ended unexpectedly` |
+| `InvalidResponse(msg)` | `Invalid response: {msg}` |
+
+Implements `std::fmt::Display` and `std::error::Error`.
+
+## Configuration
+
+No new environment variables or feature flags are introduced by this module.
+The `async-trait` crate is added as a workspace dependency.
+
+## Testing Guide
+
+Run all provider tests:
+
+```sh
+cargo test -p server --test provider_trait_tests
+```
+
+| Test | Validates |
+|------|-----------|
+| `test_mock_provider_chat_completion` | Non-streaming trait method returns correct types. |
+| `test_mock_provider_chat_completion_stream` | Streaming trait method returns chunks via channel. |
+| `test_provider_error_display` | `Display` impl for all `ProviderError` variants. |
+
+To add a new provider, implement `LlmProvider` for your struct and add
+integration tests following the `MockProvider` pattern in
+`server/tests/provider_trait_tests.rs`.
+
+## Migration / Upgrade Notes
+
+- This is a **new module** — no breaking changes to existing code.
+- The `providers` module is publicly exported from `server::providers`.
+- The `state` module is now also publicly exported from `server::state`.

--- a/server/Cargo.toml
+++ b/server/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "server"
-version = "0.4.0"
+version = "0.5.0"
 edition = "2024"
 
 [dependencies]
@@ -12,6 +12,7 @@ tracing = { workspace = true }
 tracing-subscriber = { workspace = true }
 reqwest = { workspace = true, features = ["json", "stream"] }
 tower-http = { workspace = true }
+async-trait = { workspace = true }
 
 [dev-dependencies]
 tower = { workspace = true }

--- a/server/src/lib.rs
+++ b/server/src/lib.rs
@@ -1,8 +1,10 @@
 //! LibreChat server library.
 //!
-//! Exposes the [`app`] constructor, [`AppState`], and [`resolve_port`] for use
-//! by the binary entry point and integration tests alike.
+//! Exposes the [`app`] constructor, [`AppState`], [`resolve_port`], and the
+//! [`providers`] module for use by the binary entry point and integration
+//! tests alike.
 
+pub mod providers;
 pub mod state;
 
 mod routes;

--- a/server/src/providers/mod.rs
+++ b/server/src/providers/mod.rs
@@ -1,0 +1,38 @@
+//! LLM provider abstraction layer.
+//!
+//! Defines the [`LlmProvider`] trait that all provider backends must implement,
+//! and re-exports the shared request/response types from [`types`].
+
+mod types;
+
+pub use types::*;
+
+use async_trait::async_trait;
+
+/// A trait that all LLM provider backends must implement.
+///
+/// Provides both non-streaming and streaming chat completion interfaces.
+/// Streaming uses a [`tokio::sync::mpsc`] channel receiver rather than
+/// returning a `Stream` directly, which is simpler to integrate with Axum SSE.
+#[async_trait]
+pub trait LlmProvider: Send + Sync {
+    /// Send a non-streaming chat completion request.
+    async fn chat_completion(
+        &self,
+        request: ChatCompletionRequest,
+    ) -> Result<ChatCompletionResponse, ProviderError>;
+
+    /// Send a streaming chat completion request. Returns a channel receiver
+    /// that yields [`ChatCompletionChunk`] values as they arrive from the
+    /// provider.
+    async fn chat_completion_stream(
+        &self,
+        request: ChatCompletionRequest,
+    ) -> Result<
+        tokio::sync::mpsc::Receiver<Result<ChatCompletionChunk, ProviderError>>,
+        ProviderError,
+    >;
+
+    /// Human-readable name for this provider (e.g., "Ollama", "OpenAI").
+    fn name(&self) -> &str;
+}

--- a/server/src/providers/types.rs
+++ b/server/src/providers/types.rs
@@ -1,0 +1,111 @@
+//! Shared types for LLM provider request/response handling.
+//!
+//! Types mirror the OpenAI Chat Completions API format since both Ollama and
+//! OpenAI use it. See `ROADMAP.md` Phase 1 for design rationale.
+
+use serde::{Deserialize, Serialize};
+
+/// A single message in a chat conversation.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ChatMessage {
+    pub role: MessageRole,
+    pub content: String,
+}
+
+/// Role of a participant in a chat conversation.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub enum MessageRole {
+    System,
+    User,
+    Assistant,
+}
+
+/// Request sent to an LLM provider (mirrors OpenAI Chat Completions format).
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ChatCompletionRequest {
+    pub model: String,
+    pub messages: Vec<ChatMessage>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub temperature: Option<f64>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub max_tokens: Option<u32>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub stream: Option<bool>,
+}
+
+/// Non-streaming response from an LLM provider.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ChatCompletionResponse {
+    pub id: String,
+    pub model: String,
+    pub choices: Vec<Choice>,
+    pub usage: Usage,
+}
+
+/// A single completion choice in a non-streaming response.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct Choice {
+    pub index: u32,
+    pub message: ChatMessage,
+    pub finish_reason: Option<String>,
+}
+
+/// Token usage statistics for a completion request.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct Usage {
+    pub prompt_tokens: u32,
+    pub completion_tokens: u32,
+    pub total_tokens: u32,
+}
+
+/// A single chunk in a streaming response (SSE format).
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ChatCompletionChunk {
+    pub id: String,
+    pub model: String,
+    pub choices: Vec<ChunkChoice>,
+}
+
+/// A single choice within a streaming chunk.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ChunkChoice {
+    pub index: u32,
+    pub delta: ChunkDelta,
+    pub finish_reason: Option<String>,
+}
+
+/// Delta content within a streaming chunk choice.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ChunkDelta {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub role: Option<MessageRole>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub content: Option<String>,
+}
+
+/// Errors that can occur when interacting with an LLM provider.
+#[derive(Debug)]
+pub enum ProviderError {
+    /// Failed to establish a connection to the provider.
+    ConnectionFailed(String),
+    /// The provider returned a non-success HTTP status.
+    ApiError { status: u16, message: String },
+    /// The streaming response ended unexpectedly.
+    StreamEnded,
+    /// The provider returned a response that could not be parsed.
+    InvalidResponse(String),
+}
+
+impl std::fmt::Display for ProviderError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::ConnectionFailed(msg) => write!(f, "Connection failed: {msg}"),
+            Self::ApiError { status, message } => write!(f, "API error ({status}): {message}"),
+            Self::StreamEnded => write!(f, "Stream ended unexpectedly"),
+            Self::InvalidResponse(msg) => write!(f, "Invalid response: {msg}"),
+        }
+    }
+}
+
+impl std::error::Error for ProviderError {}

--- a/server/tests/provider_trait_tests.rs
+++ b/server/tests/provider_trait_tests.rs
@@ -1,0 +1,121 @@
+//! Integration tests for the LlmProvider trait and shared chat types (Issue #5).
+
+use async_trait::async_trait;
+use server::providers::{
+    ChatCompletionChunk, ChatCompletionRequest, ChatCompletionResponse, ChatMessage, Choice,
+    ChunkChoice, ChunkDelta, LlmProvider, MessageRole, ProviderError, Usage,
+};
+use tokio::sync::mpsc;
+
+struct MockProvider;
+
+#[async_trait]
+impl LlmProvider for MockProvider {
+    async fn chat_completion(
+        &self,
+        _request: ChatCompletionRequest,
+    ) -> Result<ChatCompletionResponse, ProviderError> {
+        Ok(ChatCompletionResponse {
+            id: "test-id".to_string(),
+            model: "test-model".to_string(),
+            choices: vec![Choice {
+                index: 0,
+                message: ChatMessage {
+                    role: MessageRole::Assistant,
+                    content: "Hello from mock!".to_string(),
+                },
+                finish_reason: Some("stop".to_string()),
+            }],
+            usage: Usage {
+                prompt_tokens: 10,
+                completion_tokens: 10,
+                total_tokens: 20,
+            },
+        })
+    }
+
+    async fn chat_completion_stream(
+        &self,
+        _request: ChatCompletionRequest,
+    ) -> Result<mpsc::Receiver<Result<ChatCompletionChunk, ProviderError>>, ProviderError> {
+        let (tx, rx) = mpsc::channel(10);
+
+        tokio::spawn(async move {
+            let chunk = ChatCompletionChunk {
+                id: "stream-id".to_string(),
+                model: "test-model".to_string(),
+                choices: vec![ChunkChoice {
+                    index: 0,
+                    delta: ChunkDelta {
+                        role: None,
+                        content: Some("Hello".to_string()),
+                    },
+                    finish_reason: None,
+                }],
+            };
+            let _ = tx.send(Ok(chunk)).await;
+        });
+
+        Ok(rx)
+    }
+
+    fn name(&self) -> &str {
+        "MockProvider"
+    }
+}
+
+#[tokio::test]
+async fn test_mock_provider_chat_completion() {
+    let provider = MockProvider;
+    let request = ChatCompletionRequest {
+        model: "test-model".to_string(),
+        messages: vec![ChatMessage {
+            role: MessageRole::User,
+            content: "Hi".to_string(),
+        }],
+        temperature: None,
+        max_tokens: None,
+        stream: None,
+    };
+
+    let response = provider.chat_completion(request).await.unwrap();
+    assert_eq!(response.id, "test-id");
+    assert_eq!(response.choices[0].message.content, "Hello from mock!");
+}
+
+#[tokio::test]
+async fn test_mock_provider_chat_completion_stream() {
+    let provider = MockProvider;
+    let request = ChatCompletionRequest {
+        model: "test-model".to_string(),
+        messages: vec![ChatMessage {
+            role: MessageRole::User,
+            content: "Hi".to_string(),
+        }],
+        temperature: None,
+        max_tokens: None,
+        stream: Some(true),
+    };
+
+    let mut rx = provider.chat_completion_stream(request).await.unwrap();
+    let chunk = rx.recv().await.unwrap().unwrap();
+    assert_eq!(chunk.choices[0].delta.content.as_ref().unwrap(), "Hello");
+}
+
+#[tokio::test]
+async fn test_provider_error_display() {
+    let err = ProviderError::ConnectionFailed("timeout".to_string());
+    assert_eq!(format!("{err}"), "Connection failed: timeout");
+
+    let err = ProviderError::ApiError {
+        status: 404,
+        message: "Not Found".to_string(),
+    };
+    assert_eq!(format!("{err}"), "API error (404): Not Found");
+
+    let err = ProviderError::StreamEnded;
+    assert_eq!(format!("{err}"), "Stream ended unexpectedly");
+
+    let err = ProviderError::InvalidResponse("bad json".to_string());
+    assert_eq!(format!("{err}"), "Invalid response: bad json");
+}

--- a/wiki/providers.md
+++ b/wiki/providers.md
@@ -1,0 +1,51 @@
+# LLM Providers
+
+## What is this feature?
+
+LibreChat can talk to different AI backends (like Ollama running locally or
+OpenAI in the cloud). This feature creates a **common language** — a shared
+set of types and a trait — so the rest of the server doesn't need to know
+*which* backend it's talking to. Adding a new AI provider later means writing
+one implementation file, not rewriting the whole app.
+
+## User Guide
+
+As a user, you don't interact with the provider layer directly. It operates
+behind the scenes when you send a chat message. The provider abstraction ensures
+that whether you're using Ollama on a Raspberry Pi or OpenAI in the cloud, the
+server handles the request in the same way.
+
+## Glossary
+
+| Term | Meaning |
+|------|---------|
+| **LLM** | Large Language Model — the AI that generates responses. |
+| **Provider** | A backend that serves an LLM (e.g. Ollama, OpenAI). |
+| **Trait** | A Rust interface — a contract that each provider must follow. |
+| **Streaming** | Sending the AI response piece by piece as it's generated, rather than waiting for the whole response. |
+| **Chat Completion** | The standard API pattern: you send messages and get a completion back. |
+| **SSE** | Server-Sent Events — how streaming responses are delivered over HTTP. |
+| **Channel (`mpsc`)** | A Rust concurrency primitive used to send streaming chunks from the provider to the HTTP handler. |
+
+## FAQ / Troubleshooting
+
+**Q: Do I need to configure anything to use providers?**
+A: Not yet. This module defines the types and trait only. Configuration for
+specific providers (base URLs, API keys) will come when the Ollama and OpenAI
+implementations are added.
+
+**Q: Can I add my own provider?**
+A: Yes — implement the `LlmProvider` trait for your struct. The trait requires
+`chat_completion`, `chat_completion_stream`, and `name` methods. See the
+`MockProvider` in `server/tests/provider_trait_tests.rs` for a working example.
+
+**Q: Why does streaming use a channel instead of a Stream?**
+A: It's simpler to integrate with Axum's SSE handler. A channel receiver plugs
+directly into the HTTP response loop without needing custom `Stream`
+implementations.
+
+## Related Resources
+
+- [Technical documentation](../docs/providers.md)
+- [OpenAI Chat Completions API](https://platform.openai.com/docs/api-reference/chat)
+- [Ollama OpenAI compatibility](https://github.com/ollama/ollama/blob/main/docs/openai.md)


### PR DESCRIPTION
Closes #5

## Summary

Create the core abstraction layer for LLM providers. Defines a generic  trait and the shared request/response types that all providers will implement.

## Changes

- **`server/src/providers/types.rs`**: Shared types (`ChatMessage`, `MessageRole`, `ChatCompletionRequest`, `ChatCompletionResponse`, `Choice`, `Usage`, `ChatCompletionChunk`, `ChunkChoice`, `ChunkDelta`, `ProviderError`) mirroring the OpenAI Chat Completions format
- **`server/src/providers/mod.rs`**: `LlmProvider` trait with `chat_completion`, `chat_completion_stream`, and `name` methods using `async_trait`
- **`server/src/lib.rs`**: Publicly export `providers` module
- **`Cargo.toml`**: Add `async-trait = "0.1"` to workspace dependencies
- **`server/Cargo.toml`**: Add `async-trait` dependency, bump version to 0.5.0
- **`server/tests/provider_trait_tests.rs`**: Integration tests covering trait implementation, streaming, and error display
- **`docs/providers.md`**: Technical documentation (architecture, API reference, testing guide)
- **`wiki/providers.md`**: Feature wiki (user guide, glossary, FAQ)

## Acceptance Criteria

- [x] `LlmProvider` trait compiles with `async_trait`
- [x] All shared types derive `Serialize`, `Deserialize`, `Debug`, `Clone`
- [x] `ProviderError` implements `Display` and `Error`
- [x] `cargo build -p server` succeeds with no warnings