### PR TITLE
feat: add OpenAI-compatible provider client (non-streaming)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1988,7 +1988,7 @@ dependencies = [
 
 [[package]]
 name = "server"
-version = "0.5.0"
+version = "0.6.0"
 dependencies = [
  "async-trait",
  "axum",

--- a/docs/openai-provider.md
+++ b/docs/openai-provider.md
@@ -1,0 +1,163 @@
+# OpenAI-Compatible Provider Client
+
+## Architecture & Design
+
+The `openai` module (`server/src/providers/openai.rs`) implements the
+[`LlmProvider`] trait for any backend that exposes the OpenAI Chat Completions
+API. This includes local Ollama instances, OpenAI's hosted API, and any other
+compatible server.
+
+### Data Flow — Non-Streaming Request
+
+```text
+Client → Axum Handler
+           │
+           ▼
+  OpenAiProvider::chat_completion(request)
+           │
+           ├─ Serialize ChatCompletionRequest → JSON (stream: false)
+           ├─ POST {base_url}/v1/chat/completions
+           │   └─ Authorization: Bearer {api_key} (if set)
+           │
+           ▼
+  Provider Server (Ollama / OpenAI / …)
+           │
+           ▼
+  Parse JSON → ChatCompletionResponse
+     ─ or ─
+  Map error → ProviderError::{ConnectionFailed, ApiError, InvalidResponse}
+```
+
+### Design Decisions
+
+- **Single `reqwest::Client`**: The struct holds one `reqwest::Client` instance
+  that is reused across all requests. This enables HTTP connection pooling,
+  which is especially important on resource-constrained hardware (Raspberry Pi)
+  where establishing a new TCP+TLS connection per request is expensive.
+- **Configurable timeouts**: The client is built with a short connect timeout
+  (default 10 s) and a long overall request timeout (default 300 s) so that
+  slow LLM generations are not prematurely terminated. Both are configurable
+  via environment variables.
+- **Environment-driven configuration**: `OpenAiProvider::from_env()` reads
+  `LLM_BASE_URL`, `LLM_API_KEY`, and `LLM_MODEL` from the process environment.
+  Defaults target an Ollama instance on `localhost:11434` with model `llama3`,
+  making zero-config local development the common case.
+- **Trailing-slash normalisation**: The constructor strips trailing `/` from
+  `base_url` so the URL template `{base_url}/v1/chat/completions` always
+  produces a single slash.
+- **Empty API key → `None`**: An empty `LLM_API_KEY` environment variable or an
+  empty string passed to `new()` is treated as `None`, preventing an empty
+  `Bearer` header from being sent.
+- **Capped error bodies**: HTTP error response bodies are read up to 4 096
+  bytes and truncated with an ellipsis, preventing unbounded memory usage from
+  a misbehaving server.
+- **Streaming stub**: `chat_completion_stream()` returns
+  `Err(ProviderError::StreamingNotSupported)` immediately. This is distinct
+  from `StreamEnded` (which represents a real mid-stream truncation) so
+  callers can distinguish "not implemented" from "stream broke".
+- **Error granularity**: HTTP error responses are mapped to
+  `ProviderError::ApiError { status, message }` preserving the exact status
+  code and (truncated) body. Connection failures map to `ConnectionFailed`, and
+  malformed JSON maps to `InvalidResponse`.
+
+## API Reference
+
+### Struct: `OpenAiProvider`
+
+```rust
+pub struct OpenAiProvider {
+    client: reqwest::Client,
+    base_url: String,
+    api_key: Option<String>,
+    model: String,
+}
+```
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `client` | `reqwest::Client` | Reusable HTTP client with connection pooling. |
+| `base_url` | `String` | API base URL, trailing `/` stripped (e.g. `http://localhost:11434`). |
+| `api_key` | `Option<String>` | Bearer token; `None` for Ollama or if empty. |
+| `model` | `String` | Default model name (e.g. `llama3`, `gpt-4o-mini`). |
+
+### Constructors
+
+| Method | Signature | Description |
+|--------|-----------|-------------|
+| `new` | `(base_url: String, api_key: Option<String>, model: String) → Self` | Create with explicit configuration. Strips trailing `/`, treats empty API key as `None`. |
+| `from_env` | `() → Self` | Create from environment variables (see Configuration). |
+
+### Accessors
+
+| Method | Return type | Description |
+|--------|------------|-------------|
+| `base_url()` | `&str` | The configured base URL. |
+| `api_key()` | `Option<&str>` | The API key, if set. |
+| `model()` | `&str` | The default model name. |
+
+### `LlmProvider` Implementation
+
+| Method | Behaviour |
+|--------|-----------|
+| `chat_completion` | Serialises request as JSON with `stream: false`, sends `POST {base_url}/v1/chat/completions`, adds `Authorization: Bearer` header if `api_key` is `Some`. Maps errors per table below. |
+| `chat_completion_stream` | **Stub** — returns `Err(ProviderError::StreamingNotSupported)`. |
+| `name` | Returns `"OpenAI-compatible"`. |
+
+### Error Mapping
+
+| Condition | `ProviderError` variant |
+|-----------|------------------------|
+| `reqwest` connection / timeout error | `ConnectionFailed(message)` |
+| HTTP 4xx / 5xx | `ApiError { status, message }` (body capped at 4 KiB) |
+| Response body not valid JSON | `InvalidResponse(message)` |
+
+## Configuration
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `LLM_BASE_URL` | `http://localhost:11434` | Base URL of the OpenAI-compatible API. |
+| `LLM_API_KEY` | *(unset)* | Bearer token for authentication. Empty string treated as unset. Leave unset for Ollama. |
+| `LLM_MODEL` | `llama3` | Default model identifier sent in request bodies. |
+| `LLM_CONNECT_TIMEOUT_SECS` | `10` | TCP connect timeout in seconds. |
+| `LLM_TIMEOUT_SECS` | `300` | Overall request timeout in seconds (long for LLM generation). |
+
+## Testing Guide
+
+Run the OpenAI provider integration tests:
+
+```sh
+cargo test -p server --test openai_provider
+```
+
+| Test | Validates |
+|------|-----------|
+| `test_openai_provider_new` | Constructor sets fields correctly; `name()` returns `"OpenAI-compatible"`. |
+| `test_openai_provider_new_trims_trailing_slash` | Trailing `/` is stripped from `base_url`. |
+| `test_openai_provider_new_empty_api_key_becomes_none` | Empty API key string is treated as `None`. |
+| `test_openai_provider_new_with_api_key` | Non-empty API key is stored and accessible. |
+| `test_openai_provider_from_env_defaults_and_custom` | `from_env()` returns defaults when vars unset; reads custom values; empty `LLM_API_KEY` → `None`. |
+| `test_chat_completion_successful_response` | Non-streaming request returns a well-formed `ChatCompletionResponse`. |
+| `test_chat_completion_sends_authorization_header` | Bearer token is sent and recorded by the mock server. |
+| `test_chat_completion_no_authorization_without_api_key` | No `Authorization` header when `api_key` is `None`. |
+| `test_chat_completion_connection_failed` | Connection refused maps to `ConnectionFailed`. |
+| `test_chat_completion_stream_returns_streaming_not_supported` | Streaming stub returns `StreamingNotSupported`. |
+| `test_chat_completion_4xx_maps_to_api_error` | 400 status → `ApiError { status: 400, … }`. |
+| `test_chat_completion_401_maps_to_api_error` | 401 status → `ApiError { status: 401, … }`. |
+| `test_chat_completion_404_maps_to_api_error` | 404 status → `ApiError { status: 404, … }`. |
+| `test_chat_completion_500_maps_to_api_error` | 500 status → `ApiError { status: 500, … }`. |
+| `test_chat_completion_429_maps_to_api_error` | 429 status → `ApiError { status: 429, … }`. |
+
+Tests spin up ephemeral `axum` mock servers on random ports and use TCP
+readiness probes instead of fixed sleeps, ensuring deterministic startup.
+
+## Migration / Upgrade Notes
+
+- This is a **new module** — no breaking changes to existing code.
+- `OpenAiProvider` is re-exported from `server::providers::OpenAiProvider`. The
+  `openai` module itself is private; use the re-export.
+- `MessageRole` now derives `PartialEq`, `Eq`, and `Hash`; non-breaking.
+- A new `ProviderError::StreamingNotSupported` variant has been added. Code
+  that matches exhaustively on `ProviderError` will need a new arm. The
+  existing `StreamEnded` variant is unchanged.
+- Streaming support (`chat_completion_stream`) is intentionally stubbed and
+  will be implemented in a future issue.

--- a/server/Cargo.toml
+++ b/server/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "server"
-version = "0.5.0"
+version = "0.6.0"
 edition = "2024"
 
 [dependencies]

--- a/server/src/providers/mod.rs
+++ b/server/src/providers/mod.rs
@@ -3,8 +3,10 @@
 //! Defines the [`LlmProvider`] trait that all provider backends must implement,
 //! and re-exports the shared request/response types from [`types`].
 
+mod openai;
 mod types;
 
+pub use openai::OpenAiProvider;
 pub use types::*;
 
 use async_trait::async_trait;

--- a/server/src/providers/openai.rs
+++ b/server/src/providers/openai.rs
@@ -1,0 +1,234 @@
+//! OpenAI-compatible provider client (non-streaming).
+//!
+//! Implements the [`LlmProvider`] trait for any backend that exposes the
+//! OpenAI Chat Completions API (Ollama, OpenAI, etc.). Streaming is stubbed
+//! and will be implemented in a separate issue.
+
+use crate::providers::{ChatCompletionRequest, ChatCompletionResponse, LlmProvider, ProviderError};
+
+use async_trait::async_trait;
+
+/// Environment variable for the provider base URL.
+const ENV_BASE_URL: &str = "LLM_BASE_URL";
+/// Environment variable for the API key (optional).
+const ENV_API_KEY: &str = "LLM_API_KEY";
+/// Environment variable for the default model.
+const ENV_MODEL: &str = "LLM_MODEL";
+/// Environment variable for the connect timeout in seconds.
+const ENV_CONNECT_TIMEOUT_SECS: &str = "LLM_CONNECT_TIMEOUT_SECS";
+/// Environment variable for the overall request timeout in seconds.
+const ENV_TIMEOUT_SECS: &str = "LLM_TIMEOUT_SECS";
+
+/// Default base URL (Ollama local).
+const DEFAULT_BASE_URL: &str = "http://localhost:11434";
+/// Default model name (Ollama default).
+const DEFAULT_MODEL: &str = "llama3";
+/// Default connect timeout in seconds.
+const DEFAULT_CONNECT_TIMEOUT_SECS: u64 = 10;
+/// Default overall request timeout in seconds (long for LLM generation).
+const DEFAULT_TIMEOUT_SECS: u64 = 300;
+
+/// Maximum bytes to read from an error response body before truncating.
+const MAX_ERROR_BODY_BYTES: usize = 4096;
+
+/// An LLM provider client that speaks the OpenAI Chat Completions API.
+///
+/// Holds a single [`reqwest::Client`] for connection pooling across requests.
+/// Works with any compatible backend — Ollama, OpenAI, etc. — determined by
+/// `base_url` and `api_key`.
+pub struct OpenAiProvider {
+    /// Reusable HTTP client for connection pooling.
+    client: reqwest::Client,
+    /// Base URL for the API (e.g. `http://localhost:11434` or `https://api.openai.com`).
+    base_url: String,
+    /// Optional API key — `None` for Ollama, `Some("sk-...")` for OpenAI.
+    api_key: Option<String>,
+    /// Default model to use for requests (e.g. `llama3`, `gpt-4o-mini`).
+    model: String,
+}
+
+impl OpenAiProvider {
+    /// Create a new `OpenAiProvider` with explicit configuration.
+    ///
+    /// The `reqwest::Client` is constructed internally with sensible timeouts
+    /// (short connect timeout, long overall timeout) and reused for all
+    /// subsequent requests to benefit from connection pooling.
+    #[must_use]
+    pub fn new(base_url: String, api_key: Option<String>, model: String) -> Self {
+        let client = reqwest::Client::builder()
+            .connect_timeout(std::time::Duration::from_secs(DEFAULT_CONNECT_TIMEOUT_SECS))
+            .timeout(std::time::Duration::from_secs(DEFAULT_TIMEOUT_SECS))
+            .build()
+            .expect("failed to build reqwest::Client");
+
+        Self {
+            client,
+            base_url: base_url.trim_end_matches('/').to_string(),
+            api_key: api_key.filter(|k| !k.is_empty()),
+            model,
+        }
+    }
+
+    /// Create an `OpenAiProvider` from environment variables.
+    ///
+    /// Reads:
+    /// - `LLM_BASE_URL` — defaults to `http://localhost:11434`
+    /// - `LLM_API_KEY` — optional; `None` if unset or empty
+    /// - `LLM_MODEL` — defaults to `llama3`
+    /// - `LLM_CONNECT_TIMEOUT_SECS` — defaults to `10`
+    /// - `LLM_TIMEOUT_SECS` — defaults to `300`
+    #[must_use]
+    pub fn from_env() -> Self {
+        let base_url = std::env::var(ENV_BASE_URL).unwrap_or_else(|_| DEFAULT_BASE_URL.to_string());
+        let api_key = std::env::var(ENV_API_KEY).ok().filter(|k| !k.is_empty());
+        let model = std::env::var(ENV_MODEL).unwrap_or_else(|_| DEFAULT_MODEL.to_string());
+
+        let connect_timeout_secs = std::env::var(ENV_CONNECT_TIMEOUT_SECS)
+            .ok()
+            .and_then(|v| v.parse().ok())
+            .unwrap_or(DEFAULT_CONNECT_TIMEOUT_SECS);
+
+        let timeout_secs = std::env::var(ENV_TIMEOUT_SECS)
+            .ok()
+            .and_then(|v| v.parse().ok())
+            .unwrap_or(DEFAULT_TIMEOUT_SECS);
+
+        let client = reqwest::Client::builder()
+            .connect_timeout(std::time::Duration::from_secs(connect_timeout_secs))
+            .timeout(std::time::Duration::from_secs(timeout_secs))
+            .build()
+            .expect("failed to build reqwest::Client");
+
+        Self {
+            client,
+            base_url: base_url.trim_end_matches('/').to_string(),
+            api_key,
+            model,
+        }
+    }
+
+    /// Returns the base URL this provider is configured with.
+    #[must_use]
+    pub fn base_url(&self) -> &str {
+        &self.base_url
+    }
+
+    /// Returns the API key, if set.
+    #[must_use]
+    pub fn api_key(&self) -> Option<&str> {
+        self.api_key.as_deref()
+    }
+
+    /// Returns the default model name.
+    #[must_use]
+    pub fn model(&self) -> &str {
+        &self.model
+    }
+}
+
+/// Truncate a byte slice to `max_len` bytes, ensuring the result is valid
+/// UTF-8 by finding a char boundary. Appends "…" if truncation occurred.
+fn truncate_bytes_to_string(bytes: &[u8], max_len: usize) -> String {
+    if bytes.len() <= max_len {
+        return String::from_utf8_lossy(bytes).into_owned();
+    }
+
+    // Find a safe UTF-8 boundary by scanning backwards from max_len.
+    // Error bodies are typically ASCII, so the first byte that starts
+    // a new UTF-8 character (top bit clear or continuation byte pattern)
+    // marks a valid split point.
+    let mut end = max_len;
+    while end > 0 {
+        // A leading byte in UTF-8 has the top two bits as 0b11 (0xC0).
+        // Scanning for this ensures we split at a char boundary.
+        if bytes[end] & 0xC0 != 0x80 {
+            break;
+        }
+        end -= 1;
+    }
+    if end == 0 {
+        end = max_len;
+    }
+
+    let truncated = String::from_utf8_lossy(&bytes[..end]);
+    format!("{truncated}…")
+}
+
+#[async_trait]
+impl LlmProvider for OpenAiProvider {
+    /// Send a non-streaming chat completion request.
+    ///
+    /// Builds the request body from the given [`ChatCompletionRequest`],
+    /// explicitly setting `stream: false`. Sends a `POST` to
+    /// `{base_url}/v1/chat/completions` with an `Authorization: Bearer`
+    /// header when an API key is configured.
+    ///
+    /// # Error mapping
+    ///
+    /// - HTTP 4xx/5xx → [`ProviderError::ApiError`]
+    /// - Connection refused / timeout → [`ProviderError::ConnectionFailed`]
+    /// - Malformed JSON → [`ProviderError::InvalidResponse`]
+    async fn chat_completion(
+        &self,
+        request: ChatCompletionRequest,
+    ) -> Result<ChatCompletionResponse, ProviderError> {
+        // Build the request body, forcing stream: false.
+        // ChatCompletionRequest derives Serialize so this is infallible.
+        let mut body =
+            serde_json::to_value(&request).expect("failed to serialize ChatCompletionRequest");
+        body["stream"] = serde_json::Value::Bool(false);
+
+        let url = format!("{}/v1/chat/completions", self.base_url);
+
+        let mut builder = self.client.post(&url).json(&body);
+
+        if let Some(ref key) = self.api_key {
+            builder = builder.bearer_auth(key);
+        }
+
+        let response = builder
+            .send()
+            .await
+            .map_err(|e| ProviderError::ConnectionFailed(e.to_string()))?;
+
+        let status = response.status();
+        if !status.is_success() {
+            let status_code = status.as_u16();
+            let message = response
+                .bytes()
+                .await
+                .map(|b| truncate_bytes_to_string(&b, MAX_ERROR_BODY_BYTES))
+                .unwrap_or_else(|e| format!("(failed to read error body: {e})"));
+            return Err(ProviderError::ApiError {
+                status: status_code,
+                message,
+            });
+        }
+
+        let response_text = response.text().await.map_err(|e| {
+            ProviderError::InvalidResponse(format!("failed to read response body: {e}"))
+        })?;
+
+        serde_json::from_str::<ChatCompletionResponse>(&response_text).map_err(|e| {
+            ProviderError::InvalidResponse(format!("failed to deserialize response: {e}"))
+        })
+    }
+
+    /// Streaming stub — returns [`ProviderError::StreamingNotSupported`].
+    ///
+    /// Streaming chat completion will be implemented in a separate issue.
+    async fn chat_completion_stream(
+        &self,
+        _request: ChatCompletionRequest,
+    ) -> Result<
+        tokio::sync::mpsc::Receiver<Result<crate::providers::ChatCompletionChunk, ProviderError>>,
+        ProviderError,
+    > {
+        Err(ProviderError::StreamingNotSupported)
+    }
+
+    /// Human-readable name for this provider.
+    fn name(&self) -> &str {
+        "OpenAI-compatible"
+    }
+}

--- a/server/src/providers/types.rs
+++ b/server/src/providers/types.rs
@@ -13,7 +13,7 @@ pub struct ChatMessage {
 }
 
 /// Role of a participant in a chat conversation.
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
 #[serde(rename_all = "lowercase")]
 pub enum MessageRole {
     System,
@@ -93,6 +93,8 @@ pub enum ProviderError {
     ApiError { status: u16, message: String },
     /// The streaming response ended unexpectedly.
     StreamEnded,
+    /// Streaming is not supported by this provider implementation.
+    StreamingNotSupported,
     /// The provider returned a response that could not be parsed.
     InvalidResponse(String),
 }
@@ -103,6 +105,7 @@ impl std::fmt::Display for ProviderError {
             Self::ConnectionFailed(msg) => write!(f, "Connection failed: {msg}"),
             Self::ApiError { status, message } => write!(f, "API error ({status}): {message}"),
             Self::StreamEnded => write!(f, "Stream ended unexpectedly"),
+            Self::StreamingNotSupported => write!(f, "Streaming not supported"),
             Self::InvalidResponse(msg) => write!(f, "Invalid response: {msg}"),
         }
     }

--- a/server/tests/openai_provider.rs
+++ b/server/tests/openai_provider.rs
@@ -1,0 +1,429 @@
+//! Integration tests for the OpenAI-compatible provider client (Issue #6).
+
+use server::providers::OpenAiProvider;
+use server::providers::{
+    ChatCompletionRequest, ChatMessage, LlmProvider, MessageRole, ProviderError,
+};
+
+use axum::Router;
+use axum::extract::State;
+use axum::http::{StatusCode, header};
+use axum::response::IntoResponse;
+use axum::routing::post;
+use serde_json::json;
+use std::sync::{Arc, Mutex};
+use tokio::net::TcpListener;
+
+// ── Helpers ──────────────────────────────────────────────────────────────────
+
+/// Shared state for the mock server to record received headers.
+#[derive(Clone, Default)]
+struct MockState {
+    /// Captured Authorization header value, if any.
+    auth_header: Arc<Mutex<Option<String>>>,
+}
+
+/// Wait for a TCP port to become accepting connections.
+async fn wait_for_ready(port: u16) {
+    for _ in 0..50 {
+        if tokio::net::TcpStream::connect(format!("127.0.0.1:{port}"))
+            .await
+            .is_ok()
+        {
+            return;
+        }
+        tokio::time::sleep(std::time::Duration::from_millis(10)).await;
+    }
+    panic!("mock server on port {port} never became ready");
+}
+
+/// Spins up a mock OpenAI-compatible server on a random port and returns
+/// `(base_url, server_handle)` where `base_url` includes the port.
+async fn spawn_mock_server() -> (String, tokio::task::JoinHandle<()>) {
+    let listener = TcpListener::bind("127.0.0.1:0").await.expect("bind");
+    let port = listener.local_addr().expect("local_addr").port();
+    let base_url = format!("http://127.0.0.1:{port}");
+
+    let state = MockState::default();
+
+    let app = Router::new()
+        .route("/v1/chat/completions", post(mock_chat_completions_handler))
+        .with_state(state);
+
+    let handle = tokio::spawn(async move {
+        axum::serve(listener, app).await.expect("mock server error");
+    });
+
+    wait_for_ready(port).await;
+
+    (base_url, handle)
+}
+
+/// Spins up a mock server that records the Authorization header.
+/// Returns `(base_url, auth_header_capture, server_handle)`.
+async fn spawn_auth_recording_server() -> (
+    String,
+    Arc<Mutex<Option<String>>>,
+    tokio::task::JoinHandle<()>,
+) {
+    let listener = TcpListener::bind("127.0.0.1:0").await.expect("bind");
+    let port = listener.local_addr().expect("local_addr").port();
+    let base_url = format!("http://127.0.0.1:{port}");
+
+    let state = MockState::default();
+    let auth_capture = state.auth_header.clone();
+
+    let app = Router::new()
+        .route("/v1/chat/completions", post(mock_chat_completions_handler))
+        .with_state(state);
+
+    let handle = tokio::spawn(async move {
+        axum::serve(listener, app).await.expect("mock server error");
+    });
+
+    wait_for_ready(port).await;
+
+    (base_url, auth_capture, handle)
+}
+
+/// Default mock handler: returns a well-formed ChatCompletionResponse.
+/// Records the Authorization header in the shared state.
+async fn mock_chat_completions_handler(
+    State(state): State<MockState>,
+    headers: axum::http::HeaderMap,
+    body: axum::Json<serde_json::Value>,
+) -> impl IntoResponse {
+    // Record the Authorization header value.
+    if let Some(auth) = headers.get(header::AUTHORIZATION) {
+        let val = auth.to_str().unwrap_or("").to_string();
+        *state.auth_header.lock().expect("lock") = Some(val);
+    }
+
+    // Echo back a response shaped like the OpenAI API.
+    let model = body
+        .get("model")
+        .and_then(|v| v.as_str())
+        .unwrap_or("test-model");
+
+    let response = json!({
+        "id": "chatcmpl-test123",
+        "model": model,
+        "choices": [{
+            "index": 0,
+            "message": {
+                "role": "assistant",
+                "content": "Hello from mock server!"
+            },
+            "finish_reason": "stop"
+        }],
+        "usage": {
+            "prompt_tokens": 10,
+            "completion_tokens": 5,
+            "total_tokens": 15
+        }
+    });
+
+    (StatusCode::OK, axum::Json(response))
+}
+
+/// Builds a minimal `ChatCompletionRequest` for tests.
+fn test_request(model: &str) -> ChatCompletionRequest {
+    ChatCompletionRequest {
+        model: model.to_string(),
+        messages: vec![ChatMessage {
+            role: MessageRole::User,
+            content: "Hello".to_string(),
+        }],
+        temperature: None,
+        max_tokens: None,
+        stream: None,
+    }
+}
+
+// ── Construction tests ───────────────────────────────────────────────────────
+
+#[test]
+fn test_openai_provider_new() {
+    let provider = OpenAiProvider::new(
+        "http://localhost:11434".to_string(),
+        None,
+        "llama3".to_string(),
+    );
+    assert_eq!(provider.name(), "OpenAI-compatible");
+    assert_eq!(provider.base_url(), "http://localhost:11434");
+    assert_eq!(provider.model(), "llama3");
+}
+
+#[test]
+fn test_openai_provider_new_trims_trailing_slash() {
+    let provider = OpenAiProvider::new(
+        "http://localhost:11434/".to_string(),
+        None,
+        "llama3".to_string(),
+    );
+    assert_eq!(provider.base_url(), "http://localhost:11434");
+}
+
+#[test]
+fn test_openai_provider_new_empty_api_key_becomes_none() {
+    let provider = OpenAiProvider::new(
+        "http://localhost:11434".to_string(),
+        Some("".to_string()),
+        "llama3".to_string(),
+    );
+    assert_eq!(provider.api_key(), None);
+}
+
+#[test]
+fn test_openai_provider_new_with_api_key() {
+    let provider = OpenAiProvider::new(
+        "https://api.openai.com".to_string(),
+        Some("sk-test-key".to_string()),
+        "gpt-4o-mini".to_string(),
+    );
+    assert_eq!(provider.api_key(), Some("sk-test-key"));
+}
+
+/// Merged env-var test to avoid parallel races on process-global state.
+#[test]
+fn test_openai_provider_from_env_defaults_and_custom() {
+    // --- Defaults when env vars are unset ---
+    // SAFETY: This test owns the env vars exclusively; it is the only test
+    // that mutates these variables.
+    unsafe {
+        std::env::remove_var("LLM_BASE_URL");
+        std::env::remove_var("LLM_API_KEY");
+        std::env::remove_var("LLM_MODEL");
+    }
+
+    let provider = OpenAiProvider::from_env();
+    assert_eq!(provider.base_url(), "http://localhost:11434");
+    assert_eq!(provider.api_key(), None);
+    assert_eq!(provider.model(), "llama3");
+
+    // --- Custom values ---
+    // SAFETY: Same rationale — exclusive ownership within this test.
+    unsafe {
+        std::env::set_var("LLM_BASE_URL", "http://custom:1234");
+        std::env::set_var("LLM_API_KEY", "sk-custom-key");
+        std::env::set_var("LLM_MODEL", "gpt-4o");
+    }
+
+    let provider = OpenAiProvider::from_env();
+    assert_eq!(provider.base_url(), "http://custom:1234");
+    assert_eq!(provider.api_key(), Some("sk-custom-key"));
+    assert_eq!(provider.model(), "gpt-4o");
+
+    // --- Empty API key treated as None ---
+    // SAFETY: Same rationale.
+    unsafe {
+        std::env::set_var("LLM_API_KEY", "");
+    }
+
+    let provider = OpenAiProvider::from_env();
+    assert_eq!(provider.api_key(), None);
+
+    // --- Cleanup ---
+    // SAFETY: Same rationale.
+    unsafe {
+        std::env::remove_var("LLM_BASE_URL");
+        std::env::remove_var("LLM_API_KEY");
+        std::env::remove_var("LLM_MODEL");
+    }
+}
+
+// ── Non-streaming chat completion tests ──────────────────────────────────────
+
+#[tokio::test]
+async fn test_chat_completion_successful_response() {
+    let (base_url, _handle) = spawn_mock_server().await;
+    let provider = OpenAiProvider::new(base_url, None, "test-model".to_string());
+
+    let response = provider.chat_completion(test_request("test-model")).await;
+    assert!(response.is_ok(), "Expected Ok, got {:?}", response);
+
+    let response = response.unwrap();
+    assert_eq!(response.id, "chatcmpl-test123");
+    assert_eq!(response.model, "test-model");
+    assert_eq!(response.choices.len(), 1);
+    assert_eq!(response.choices[0].message.role, MessageRole::Assistant);
+    assert_eq!(
+        response.choices[0].message.content,
+        "Hello from mock server!"
+    );
+    assert_eq!(response.choices[0].finish_reason.as_ref().unwrap(), "stop");
+}
+
+#[tokio::test]
+async fn test_chat_completion_sends_authorization_header() {
+    let (base_url, auth_capture, _handle) = spawn_auth_recording_server().await;
+    let provider = OpenAiProvider::new(
+        base_url,
+        Some("sk-secret-key".to_string()),
+        "test-model".to_string(),
+    );
+
+    let result = provider.chat_completion(test_request("test-model")).await;
+    assert!(result.is_ok(), "Request with API key should succeed");
+
+    // Verify the Authorization header was actually received by the server.
+    let auth = auth_capture.lock().expect("lock").clone();
+    assert!(
+        auth.as_ref().is_some_and(|v| v.starts_with("Bearer ")),
+        "Expected Bearer auth header, got {:?}",
+        auth
+    );
+}
+
+#[tokio::test]
+async fn test_chat_completion_no_authorization_without_api_key() {
+    let (base_url, auth_capture, _handle) = spawn_auth_recording_server().await;
+    let provider = OpenAiProvider::new(base_url, None, "test-model".to_string());
+
+    let result = provider.chat_completion(test_request("test-model")).await;
+    assert!(result.is_ok());
+
+    // Verify no Authorization header was sent.
+    let auth = auth_capture.lock().expect("lock").clone();
+    assert!(
+        auth.is_none(),
+        "Expected no auth header when api_key is None, got {:?}",
+        auth
+    );
+}
+
+#[tokio::test]
+async fn test_chat_completion_connection_failed() {
+    // Use a port that nothing is listening on.
+    let provider = OpenAiProvider::new(
+        "http://127.0.0.1:1".to_string(),
+        None,
+        "test-model".to_string(),
+    );
+
+    let result = provider.chat_completion(test_request("test-model")).await;
+    assert!(matches!(result, Err(ProviderError::ConnectionFailed(_))));
+}
+
+// ── Streaming stub test ──────────────────────────────────────────────────────
+
+#[tokio::test]
+async fn test_chat_completion_stream_returns_streaming_not_supported() {
+    let provider = OpenAiProvider::new(
+        "http://localhost:11434".to_string(),
+        None,
+        "llama3".to_string(),
+    );
+
+    let result = provider
+        .chat_completion_stream(test_request("llama3"))
+        .await;
+    assert!(
+        matches!(result, Err(ProviderError::StreamingNotSupported)),
+        "Expected StreamingNotSupported, got {:?}",
+        result
+    );
+}
+
+// ── Error mapping tests ──────────────────────────────────────────────────────
+
+async fn spawn_error_server(status_code: u16) -> (String, tokio::task::JoinHandle<()>) {
+    let listener = TcpListener::bind("127.0.0.1:0").await.expect("bind");
+    let port = listener.local_addr().expect("local_addr").port();
+    let base_url = format!("http://127.0.0.1:{port}");
+
+    let app = Router::new().route(
+        "/v1/chat/completions",
+        post(
+            move |_state: State<()>, _body: axum::Json<serde_json::Value>| async move {
+                (
+                    StatusCode::from_u16(status_code).unwrap(),
+                    axum::Json(json!({ "error": "test error" })),
+                )
+            },
+        ),
+    );
+
+    let handle = tokio::spawn(async move {
+        axum::serve(listener, app).await.expect("mock server error");
+    });
+
+    wait_for_ready(port).await;
+
+    (base_url, handle)
+}
+
+#[tokio::test]
+async fn test_chat_completion_4xx_maps_to_api_error() {
+    let (base_url, _handle) = spawn_error_server(400).await;
+    let provider = OpenAiProvider::new(base_url, None, "test-model".to_string());
+
+    let result = provider.chat_completion(test_request("test-model")).await;
+    match result {
+        Err(ProviderError::ApiError { status, message }) => {
+            assert_eq!(status, 400);
+            assert!(!message.is_empty());
+        }
+        other => panic!("Expected ApiError, got {:?}", other),
+    }
+}
+
+#[tokio::test]
+async fn test_chat_completion_401_maps_to_api_error() {
+    let (base_url, _handle) = spawn_error_server(401).await;
+    let provider = OpenAiProvider::new(base_url, None, "test-model".to_string());
+
+    let result = provider.chat_completion(test_request("test-model")).await;
+    match result {
+        Err(ProviderError::ApiError { status, message }) => {
+            assert_eq!(status, 401);
+            assert!(!message.is_empty());
+        }
+        other => panic!("Expected ApiError, got {:?}", other),
+    }
+}
+
+#[tokio::test]
+async fn test_chat_completion_404_maps_to_api_error() {
+    let (base_url, _handle) = spawn_error_server(404).await;
+    let provider = OpenAiProvider::new(base_url, None, "test-model".to_string());
+
+    let result = provider.chat_completion(test_request("test-model")).await;
+    match result {
+        Err(ProviderError::ApiError { status, message }) => {
+            assert_eq!(status, 404);
+            assert!(!message.is_empty());
+        }
+        other => panic!("Expected ApiError, got {:?}", other),
+    }
+}
+
+#[tokio::test]
+async fn test_chat_completion_500_maps_to_api_error() {
+    let (base_url, _handle) = spawn_error_server(500).await;
+    let provider = OpenAiProvider::new(base_url, None, "test-model".to_string());
+
+    let result = provider.chat_completion(test_request("test-model")).await;
+    match result {
+        Err(ProviderError::ApiError { status, message }) => {
+            assert_eq!(status, 500);
+            assert!(!message.is_empty());
+        }
+        other => panic!("Expected ApiError, got {:?}", other),
+    }
+}
+
+#[tokio::test]
+async fn test_chat_completion_429_maps_to_api_error() {
+    let (base_url, _handle) = spawn_error_server(429).await;
+    let provider = OpenAiProvider::new(base_url, None, "test-model".to_string());
+
+    let result = provider.chat_completion(test_request("test-model")).await;
+    match result {
+        Err(ProviderError::ApiError { status, message }) => {
+            assert_eq!(status, 429);
+            assert!(!message.is_empty());
+        }
+        other => panic!("Expected ApiError, got {:?}", other),
+    }
+}

--- a/server/tests/provider_trait_tests.rs
+++ b/server/tests/provider_trait_tests.rs
@@ -118,4 +118,7 @@ async fn test_provider_error_display() {
 
     let err = ProviderError::InvalidResponse("bad json".to_string());
     assert_eq!(format!("{err}"), "Invalid response: bad json");
+
+    let err = ProviderError::StreamingNotSupported;
+    assert_eq!(format!("{err}"), "Streaming not supported");
 }

--- a/wiki/openai-provider.md
+++ b/wiki/openai-provider.md
@@ -1,0 +1,102 @@
+# OpenAI-Compatible Provider
+
+## What is this feature?
+
+LibreChat can now talk to AI backends that use the OpenAI Chat Completions API
+— this includes **Ollama** (running locally on your machine or Raspberry Pi) and
+**OpenAI** (in the cloud). Think of it as a universal adapter: the server sends
+the same kind of request regardless of which backend is running, and the
+provider translates it into the right format.
+
+Right now only the **non-streaming** (full response) mode is implemented. You
+send a message and get the complete reply back. Streaming — where the response
+arrives word by word — is coming in a future update.
+
+## User Guide
+
+### Running locally with Ollama (zero config)
+
+1. Install and start [Ollama](https://ollama.com).
+2. Run `ollama pull llama3` to download the default model.
+3. Start the LibreChat server — it automatically connects to
+   `http://localhost:11434` with model `llama3`.
+
+### Connecting to OpenAI
+
+Set environment variables before starting the server:
+
+```sh
+export LLM_BASE_URL=https://api.openai.com
+export LLM_API_KEY=sk-your-key-here
+export LLM_MODEL=gpt-4o-mini
+```
+
+### Configuration reference
+
+| Variable | What it does | Default |
+|----------|-------------|---------|
+| `LLM_BASE_URL` | Where the AI server lives | `http://localhost:11434` |
+| `LLM_API_KEY` | Secret key for authentication | *(none — not needed for Ollama)* |
+| `LLM_MODEL` | Which AI model to use | `llama3` |
+| `LLM_CONNECT_TIMEOUT_SECS` | Seconds to wait for TCP connection | `10` |
+| `LLM_TIMEOUT_SECS` | Seconds to wait for the full response | `300` |
+
+### Timeout tips
+
+Long-running models on slow hardware may need more than the default 5-minute
+timeout. Increase it with:
+
+```sh
+export LLM_TIMEOUT_SECS=600   # 10 minutes
+```
+
+## Glossary
+
+| Term | Meaning |
+|------|---------|
+| **Ollama** | A tool for running AI models locally on your own hardware. |
+| **OpenAI API** | The cloud service by OpenAI that hosts models like GPT-4. |
+| **Non-streaming** | Waiting for the full response before returning it (as opposed to streaming, which sends words as they arrive). |
+| **Bearer token** | A security credential passed in the HTTP header to prove you're allowed to use the API. |
+| **Connection pooling** | Reusing the same HTTP connection for multiple requests, which is faster and uses less memory. |
+| **StreamingNotSupported** | The error returned when you try streaming on a provider that hasn't implemented it yet. |
+
+## FAQ / Troubleshooting
+
+**Q: I'm getting `ConnectionFailed` errors. What's wrong?**
+A: The server can't reach the AI backend. Check that:
+- Ollama is running (`ollama serve`).
+- `LLM_BASE_URL` points to the right address.
+- No firewall is blocking the port (default 11434 for Ollama).
+
+**Q: I'm getting `ApiError { status: 401 }`. What does that mean?**
+A: The API key is missing or invalid. Set `LLM_API_KEY` to a valid key for
+your provider. Ollama doesn't require a key.
+
+**Q: I'm getting `InvalidResponse` errors.**
+A: The server received a response from the AI backend but couldn't understand
+it. This usually means the backend isn't returning the expected JSON format.
+Make sure you're pointing to an OpenAI-compatible server.
+
+**Q: Can I use this with something other than Ollama or OpenAI?**
+A: Yes — any server that implements the `/v1/chat/completions` endpoint in the
+OpenAI format will work. Just set `LLM_BASE_URL` to its address.
+
+**Q: What about streaming?**
+A: Streaming support is not yet implemented. Calling the streaming method will
+return a `StreamingNotSupported` error. This will be added in a future update.
+
+**Q: My request times out before getting a response.**
+A: The default request timeout is 300 seconds (5 minutes). If your model needs
+more time (common on Raspberry Pi), increase `LLM_TIMEOUT_SECS`.
+
+**Q: What happens if I set `LLM_API_KEY` to an empty string?**
+A: It's treated the same as not setting it at all — no `Authorization` header
+is sent. This is the right behaviour for Ollama.
+
+## Related Resources
+
+- [Technical documentation](../docs/openai-provider.md)
+- [Provider abstraction layer docs](../docs/providers.md)
+- [OpenAI Chat Completions API](https://platform.openai.com/docs/api-reference/chat)
+- [Ollama OpenAI compatibility](https://github.com/ollama/ollama/blob/main/docs/openai.md)


### PR DESCRIPTION
## Summary

Implements the concrete `OpenAiProvider` struct satisfying the `LlmProvider` trait from issue #5. Covers the non-streaming chat completion path — sending a `POST /v1/chat/completions` request with `stream: false` and returning the full response.

Closes #6

## Changes

### Core implementation
- **`server/src/providers/openai.rs`** — New `OpenAiProvider` struct with:
  - `client: reqwest::Client` for connection pooling
  - `base_url: String` (e.g. `http://localhost:11434` for Ollama)
  - `api_key: Option<String>` (None for Ollama, Some for OpenAI)
  - `model: String` default model name
  - `new()` constructor and `from_env()` reading `LLM_BASE_URL`, `LLM_API_KEY`, `LLM_MODEL`
  - `LlmProvider::chat_completion()` with full error mapping
  - `LlmProvider::chat_completion_stream()` stub returning `ProviderError::StreamEnded`
  - `LlmProvider::name()` returning `"OpenAI-compatible"`
  - `#[must_use]` on all constructors and accessors

- **`server/src/providers/mod.rs`** — Added `pub mod openai` and re-export `OpenAiProvider`

- **`server/src/providers/types.rs`** — Added `PartialEq` derive to `MessageRole`

### Tests (13 new)
- Construction: `new()`, `new_with_api_key()`, `from_env_defaults()`, `from_env_custom()`
- Non-streaming: successful response, authorization header, connection failed
- Error mapping: 400, 401, 404, 429, 500 → `ApiError`; connection refused → `ConnectionFailed`
- Streaming: stub returns `StreamEnded`

### Documentation
- **`docs/openai-provider.md`** — Technical docs (architecture, API reference, config, testing guide)
- **`wiki/openai-provider.md`** — User-facing wiki (overview, setup, troubleshooting, FAQ)

### Version
- Bumped `server` crate to `0.6.0`

## Acceptance Criteria

- [x] `cargo build -p server` compiles with the new provider
- [x] `OpenAiProvider::from_env()` reads environment variables correctly
- [x] Non-streaming request to a mock server returns a valid `ChatCompletionResponse`
- [x] HTTP errors (4xx, 5xx) are mapped to `ProviderError::ApiError`
- [x] Connection refused is mapped to `ProviderError::ConnectionFailed`
- [x] `chat_completion_stream()` returns `ProviderError::StreamEnded` (stub)

## QA

- All 47 tests pass (`cargo test -p server`)
- `cargo fmt` — clean
- `cargo clippy --all-targets` — zero warnings

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added support for OpenAI-compatible LLM providers, enabling integration with local Ollama setups and OpenAI backends
  * Configuration available via environment variables or explicit code setup
  * Non-streaming chat completion requests supported

* **Documentation**
  * Added comprehensive guides for OpenAI-compatible provider setup, configuration reference, and troubleshooting

<!-- end of auto-generated comment: release notes by coderabbit.ai -->