### PR TITLE
feat: connect Leptos frontend to non-streaming chat API

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -511,9 +511,13 @@ dependencies = [
 
 [[package]]
 name = "frontend"
-version = "0.3.0"
+version = "0.4.0"
 dependencies = [
+ "gloo-net",
+ "js-sys",
  "leptos",
+ "serde",
+ "serde_json",
  "wasm-bindgen",
  "web-sys",
 ]

--- a/docs/frontend-api-integration.md
+++ b/docs/frontend-api-integration.md
@@ -19,9 +19,9 @@ User types message → ChatInput::on_send
 
 ```text
 ChatView (owns signal<Vec<ChatMessage>>, signal<bool> loading)
-├── MessageList (receives ReadSignal<Vec<ChatMessage>>)
-│   └── For each message → <div class="message-bubble message-{role}[-message-error]">
-├── Loading indicator (conditional on loading signal)
+├── MessageList (receives ReadSignal<Vec<ChatMessage>>, Signal<bool> loading)
+│   ├── For each message → <div class="message-bubble message-{role}[-message-error]">
+│   └── Loading indicator (conditional on loading signal — "Thinking…" bubble)
 └── ChatInput (receives on_send + disabled signal)
     └── textarea + send-btn (both disabled when loading = true)
 ```
@@ -140,7 +140,8 @@ Added `is_error: bool` field. When `true`, the message bubble is styled with the
 - On send: appends User message, sets `loading = true`, spawns `send_chat_request` via `leptos::task::spawn_local`.
 - On response success: appends Assistant message, sets `loading = false`.
 - On response error: appends error message with `is_error = true`, sets `loading = false`.
-- Renders a "Thinking…" loading indicator conditionally between `MessageList` and `ChatInput`.
+- On empty choices: appends error message with `is_error = true` and content `"(empty response from model)"`, sets `loading = false`.
+- The `MessageList` child receives the `loading` signal and renders a "Thinking…" indicator inside the message list when `loading` is `true`.
 
 #### `ChatInput` (Updated)
 
@@ -177,7 +178,7 @@ Structural tests live in `server/tests/frontend_api_integration.rs` and verify:
 - `frontend/src/api.rs` exists and defines expected types and functions
 - `frontend/src/lib.rs` declares `mod api`
 - `ChatMessage` has `is_error: bool` field
-- `ChatView` uses `signal(false)` for loading, calls `send_chat_request`, and shows "Thinking…"
+- `ChatView` uses `signal(false)` for loading and calls `send_chat_request`; `MessageList` renders the "Thinking…" indicator
 - `ChatInput` accepts a `disabled` prop and binds it to textarea/button
 - CSS defines `.message-error` and `.message-loading` classes
 - `frontend/Cargo.toml` includes `gloo-net`, `serde`, and `js-sys`

--- a/docs/frontend-api-integration.md
+++ b/docs/frontend-api-integration.md
@@ -190,16 +190,15 @@ Unit tests in `frontend/src/api.rs::tests` cover:
 
 Run all tests: `cargo test`
 
+Run only the server integration tests:
+`cargo test -p server --test frontend_api_integration`
+
+Run only the frontend crate api module tests:
+`cargo test -p frontend api::tests`
+
 ## Migration / Upgrade Notes
 
 - The `is_error` field was added to `ChatMessage`. Any code constructing `ChatMessage` must set `is_error: false` for normal messages.
 - The `ChatInput` component now requires a `disabled` prop. Callers must pass a `Signal<bool>`.
 - The previous "Echo" simulation has been replaced with real backend API calls. To revert, remove the `spawn_local` block and restore the echo logic.
 - For streaming support, a future change would replace `send_chat_request` with an SSE-based streaming client and render tokens incrementally.
-Run all tests: `cargo test`
-
-Run only the server integration tests:
-`cargo test -p server --test frontend_api_integration`
-
-Run only the frontend crate api module tests:
-`cargo test -p frontend api::tests`

--- a/docs/frontend-api-integration.md
+++ b/docs/frontend-api-integration.md
@@ -196,3 +196,10 @@ Run all tests: `cargo test`
 - The `ChatInput` component now requires a `disabled` prop. Callers must pass a `Signal<bool>`.
 - The previous "Echo" simulation has been replaced with real backend API calls. To revert, remove the `spawn_local` block and restore the echo logic.
 - For streaming support, a future change would replace `send_chat_request` with an SSE-based streaming client and render tokens incrementally.
+Run all tests: `cargo test`
+
+Run only the server integration tests:
+`cargo test -p server --test frontend_api_integration`
+
+Run only the frontend crate api module tests:
+`cargo test -p frontend api::tests`

--- a/docs/frontend-api-integration.md
+++ b/docs/frontend-api-integration.md
@@ -1,0 +1,198 @@
+# Frontend API Integration — Technical Documentation
+
+## Architecture & Design
+
+This feature connects the Leptos CSR frontend to the backend non-streaming chat completions endpoint (`POST /api/chat/completions`). The architecture adds an API client layer and reactive loading/error states to the existing `ChatView` component.
+
+### Data Flow
+
+```text
+User types message → ChatInput::on_send
+  → ChatView appends User message to signal
+  → ChatView sets loading = true
+  → spawn_local { send_chat_request(messages) }
+      → on success: append Assistant message, loading = false
+      → on error:   append error message (is_error = true), loading = false
+```
+
+### Component Hierarchy (Updated)
+
+```text
+ChatView (owns signal<Vec<ChatMessage>>, signal<bool> loading)
+├── MessageList (receives ReadSignal<Vec<ChatMessage>>)
+│   └── For each message → <div class="message-bubble message-{role}[-message-error]">
+├── Loading indicator (conditional on loading signal)
+└── ChatInput (receives on_send + disabled signal)
+    └── textarea + send-btn (both disabled when loading = true)
+```
+
+### Module Layout
+
+```text
+frontend/src/
+├── lib.rs           — App root, declares mod api
+├── api.rs           — HTTP client, API types, send_chat_request
+└── components/
+    ├── mod.rs        — Re-exports chat module
+    └── chat.rs       — ChatView, MessageList, ChatInput, ChatMessage, MessageRole
+```
+
+## API Reference
+
+### `api` Module (`frontend/src/api.rs`)
+
+#### `send_chat_request`
+
+```rust
+pub async fn send_chat_request(
+    messages: &[ApiChatMessage],
+    model: &str,
+) -> Result<ApiChatCompletionResponse, ApiError>
+```
+
+Sends a `POST /api/chat/completions` request with the given conversation history. When `model` is empty, it defaults to [`DEFAULT_MODEL`] (`"llama3"`). Returns the full non-streaming response or an [`ApiError`].
+
+#### `ApiMessageRole`
+
+```rust
+pub enum ApiMessageRole {
+    System,
+    User,
+    Assistant,
+}
+```
+
+Serialised as lowercase strings via `#[serde(rename_all = "lowercase")]`. Mirrors the server's `MessageRole` but lives in the frontend crate to avoid WASM-incompatible server dependencies.
+
+#### `ApiChatCompletionRequest`
+
+```rust
+pub struct ApiChatCompletionRequest {
+    pub model: String,
+    pub messages: Vec<ApiChatMessage>,
+    pub temperature: Option<f64>,
+    pub max_tokens: Option<u32>,
+    pub stream: Option<bool>,
+}
+```
+
+Serialises with `skip_serializing_if = "Option::is_none"` for optional fields. The `stream` field is always set to `Some(false)` by `send_chat_request`.
+
+#### `ApiChatCompletionResponse`
+
+```rust
+pub struct ApiChatCompletionResponse {
+    pub id: String,
+    pub model: String,
+    pub choices: Vec<ApiChoice>,
+    pub usage: ApiUsage,
+}
+```
+
+Deserialised from the backend JSON response. The `choices[0].message.content` field is used as the assistant reply text.
+
+#### `ApiError`
+
+```rust
+pub enum ApiError {
+    Network(String),       // Network-level failure (CORS, DNS, etc.)
+    Http { status: u16, body: String },  // Non-2xx HTTP response
+    Parse(String),         // JSON deserialisation failure
+}
+```
+
+Implements `Display` for user-facing error messages displayed in the chat UI.
+
+#### `DEFAULT_MODEL`
+
+```rust
+pub const DEFAULT_MODEL: &str = "llama3";
+```
+
+The model identifier used when no model is explicitly specified. Change this constant to target a different Ollama model.
+
+#### `api_base_url`
+
+```rust
+fn api_base_url() -> String
+```
+
+Reads `window.__LIBRECHAT_API_URL__` from the JavaScript global scope. Returns an empty string when unset, which results in relative URLs (correct for same-origin deployments).
+
+### `components::chat` Module (Updated)
+
+#### `ChatMessage` (Updated)
+
+```rust
+pub struct ChatMessage {
+    pub id: usize,
+    pub role: MessageRole,
+    pub content: String,
+    pub is_error: bool,
+}
+```
+
+Added `is_error: bool` field. When `true`, the message bubble is styled with the `.message-error` CSS class instead of `.message-assistant`.
+
+#### `ChatView` (Updated)
+
+- Added `loading` signal (`signal(false)`) to track in-flight requests.
+- On send: appends User message, sets `loading = true`, spawns `send_chat_request` via `leptos::task::spawn_local`.
+- On response success: appends Assistant message, sets `loading = false`.
+- On response error: appends error message with `is_error = true`, sets `loading = false`.
+- Renders a "Thinking…" loading indicator conditionally between `MessageList` and `ChatInput`.
+
+#### `ChatInput` (Updated)
+
+```rust
+pub fn ChatInput(
+    on_send: impl Fn(String) + Copy + 'static,
+    #[prop(into)] disabled: Signal<bool>,
+) -> impl IntoView
+```
+
+Added `disabled: Signal<bool>` prop. When `true` (during in-flight requests), both the `<textarea>` and `<button>` are disabled. The send button is also disabled when the input text is empty.
+
+## CSS Classes (New)
+
+| Class               | Purpose                                        |
+| ------------------- | ---------------------------------------------- |
+| `.message-loading`  | Pulsing "Thinking…" indicator while awaiting response |
+| `.message-error`    | Error-styled assistant bubble (red background) |
+| `.chat-textarea:disabled` | Reduced opacity and cursor for in-flight state |
+
+The `.message-loading` class uses a `pulse-opacity` CSS keyframe animation (1.4s ease-in-out infinite) that fades between full and 40% opacity.
+
+## Configuration
+
+| Setting                       | Type   | Default | Description                                       |
+| ----------------------------- | ------ | ------- | ------------------------------------------------- |
+| `window.__LIBRECHAT_API_URL__` | `string` | `""`    | Override API base URL (empty = relative, same-origin) |
+| `DEFAULT_MODEL` (constant)    | `&str` | `"llama3"` | Model identifier sent in chat completion requests |
+
+## Testing Guide
+
+Structural tests live in `server/tests/frontend_api_integration.rs` and verify:
+
+- `frontend/src/api.rs` exists and defines expected types and functions
+- `frontend/src/lib.rs` declares `mod api`
+- `ChatMessage` has `is_error: bool` field
+- `ChatView` uses `signal(false)` for loading, calls `send_chat_request`, and shows "Thinking…"
+- `ChatInput` accepts a `disabled` prop and binds it to textarea/button
+- CSS defines `.message-error` and `.message-loading` classes
+- `frontend/Cargo.toml` includes `gloo-net`, `serde`, and `js-sys`
+
+Unit tests in `frontend/src/api.rs::tests` cover:
+- `ApiError::Display` implementations
+- `ApiMessageRole` serialisation
+- `ApiChatCompletionRequest` serialisation (skips `None` fields)
+- `DEFAULT_MODEL` value
+
+Run all tests: `cargo test`
+
+## Migration / Upgrade Notes
+
+- The `is_error` field was added to `ChatMessage`. Any code constructing `ChatMessage` must set `is_error: false` for normal messages.
+- The `ChatInput` component now requires a `disabled` prop. Callers must pass a `Signal<bool>`.
+- The previous "Echo" simulation has been replaced with real backend API calls. To revert, remove the `spawn_local` block and restore the echo logic.
+- For streaming support, a future change would replace `send_chat_request` with an SSE-based streaming client and render tokens incrementally.

--- a/frontend/Cargo.toml
+++ b/frontend/Cargo.toml
@@ -1,12 +1,16 @@
 [package]
 name = "frontend"
-version = "0.3.0"
+version = "0.4.0"
 edition = "2021"
 
 [dependencies]
 leptos = { workspace = true }
 wasm-bindgen = { workspace = true }
-web-sys = { version = "0.3", features = ["KeyboardEvent", "HtmlDivElement", "ScrollToOptions", "Element", "HtmlTextAreaElement"] }
+serde = { workspace = true }
+serde_json = { workspace = true }
+gloo-net = { version = "0.6", features = ["json"] }
+js-sys = "0.3"
+web-sys = { version = "0.3", features = ["KeyboardEvent", "HtmlDivElement", "ScrollToOptions", "Element", "HtmlTextAreaElement", "Window"] }
 
 [lib]
 crate-type = ["cdylib", "rlib"]

--- a/frontend/src/api.rs
+++ b/frontend/src/api.rs
@@ -1,0 +1,229 @@
+//! Frontend API client for the LibreChat non-streaming chat endpoint.
+//!
+//! Provides [`send_chat_request`] which posts a conversation history to the
+//! backend `POST /api/chat/completions` endpoint and returns the full
+//! [`ApiChatCompletionResponse`]. The API base URL is configurable via the
+//! `window.__LIBRECHAT_API_URL__` JavaScript property (default: current origin).
+
+use gloo_net::http::Request;
+use serde::{Deserialize, Serialize};
+
+/// Default model used when the caller does not specify one.
+pub const DEFAULT_MODEL: &str = "llama3";
+
+/// Role of a participant in a chat conversation (API serialisation format).
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "lowercase")]
+pub enum ApiMessageRole {
+    System,
+    User,
+    Assistant,
+}
+
+/// A single message in a chat conversation (API serialisation format).
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ApiChatMessage {
+    pub role: ApiMessageRole,
+    pub content: String,
+}
+
+/// Request payload sent to `POST /api/chat/completions`.
+#[derive(Debug, Clone, Serialize)]
+pub struct ApiChatCompletionRequest {
+    pub model: String,
+    pub messages: Vec<ApiChatMessage>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub temperature: Option<f64>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub max_tokens: Option<u32>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub stream: Option<bool>,
+}
+
+/// Non-streaming response received from the chat completions endpoint.
+///
+/// Fields `id`, `model`, and `usage` are deserialized from the server response
+/// but not yet consumed by the frontend — they are kept to maintain a
+/// complete API contract for future use.
+#[allow(dead_code)]
+#[derive(Debug, Clone, Deserialize)]
+pub struct ApiChatCompletionResponse {
+    pub id: String,
+    pub model: String,
+    pub choices: Vec<ApiChoice>,
+    pub usage: ApiUsage,
+}
+
+/// A single completion choice in a non-streaming response.
+///
+/// Fields `index` and `finish_reason` are kept for API completeness.
+#[allow(dead_code)]
+#[derive(Debug, Clone, Deserialize)]
+pub struct ApiChoice {
+    pub index: u32,
+    pub message: ApiChatMessage,
+    pub finish_reason: Option<String>,
+}
+
+/// Token usage statistics returned by the provider.
+///
+/// Kept for API completeness; not yet displayed in the UI.
+#[allow(dead_code)]
+#[derive(Debug, Clone, Deserialize)]
+pub struct ApiUsage {
+    pub prompt_tokens: u32,
+    pub completion_tokens: u32,
+    pub total_tokens: u32,
+}
+
+/// Errors that can occur when calling the chat completions API.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum ApiError {
+    /// The network request failed (e.g. CORS, DNS, connection refused).
+    Network(String),
+    /// The server returned a non-2xx HTTP status code.
+    Http { status: u16, body: String },
+    /// The response body could not be parsed as valid JSON.
+    Parse(String),
+}
+
+impl std::fmt::Display for ApiError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            ApiError::Network(msg) => write!(f, "Network error: {msg}"),
+            ApiError::Http { status, body } => write!(f, "HTTP {status}: {body}"),
+            ApiError::Parse(msg) => write!(f, "Failed to parse response: {msg}"),
+        }
+    }
+}
+
+/// Read the API base URL from the `window.__LIBRECHAT_API_URL__` JavaScript
+/// property. Returns an empty string (i.e. relative URLs) when the property
+/// is not set, which works correctly when the frontend is served by the same
+/// origin as the backend.
+fn api_base_url() -> String {
+    use web_sys::window;
+
+    let Some(win) = window() else {
+        return String::new();
+    };
+
+    let Ok(value) = js_sys::Reflect::get(
+        &win.into(),
+        &js_sys::JsString::from("__LIBRECHAT_API_URL__"),
+    ) else {
+        return String::new();
+    };
+
+    value.as_string().unwrap_or_default()
+}
+
+/// Send a non-streaming chat completion request to the backend.
+///
+/// Constructs a `POST /api/chat/completions` request with the given messages
+/// and model, then awaits the full response. The model defaults to
+/// [`DEFAULT_MODEL`] when an empty string is supplied.
+pub async fn send_chat_request(
+    messages: &[ApiChatMessage],
+    model: &str,
+) -> Result<ApiChatCompletionResponse, ApiError> {
+    let base = api_base_url();
+    let url = format!("{base}/api/chat/completions");
+
+    let request = ApiChatCompletionRequest {
+        model: if model.is_empty() {
+            DEFAULT_MODEL.to_string()
+        } else {
+            model.to_string()
+        },
+        messages: messages.to_vec(),
+        temperature: None,
+        max_tokens: None,
+        stream: Some(false),
+    };
+
+    let response = Request::post(&url)
+        .json(&request)
+        .map_err(|e| ApiError::Network(e.to_string()))?
+        .send()
+        .await
+        .map_err(|e| ApiError::Network(e.to_string()))?;
+
+    let status = response.status();
+
+    if !response.ok() {
+        let body = response
+            .text()
+            .await
+            .unwrap_or_else(|_| "<no body>".to_string());
+        return Err(ApiError::Http {
+            status,
+            body: body.chars().take(512).collect(),
+        });
+    }
+
+    response
+        .json()
+        .await
+        .map_err(|e| ApiError::Parse(e.to_string()))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_default_model_constant() {
+        assert_eq!(DEFAULT_MODEL, "llama3");
+    }
+
+    #[test]
+    fn test_api_error_display_network() {
+        let err = ApiError::Network("connection refused".to_string());
+        assert_eq!(format!("{err}"), "Network error: connection refused");
+    }
+
+    #[test]
+    fn test_api_error_display_http() {
+        let err = ApiError::Http {
+            status: 502,
+            body: "bad gateway".to_string(),
+        };
+        assert_eq!(format!("{err}"), "HTTP 502: bad gateway");
+    }
+
+    #[test]
+    fn test_api_error_display_parse() {
+        let err = ApiError::Parse("invalid json".to_string());
+        assert_eq!(format!("{err}"), "Failed to parse response: invalid json");
+    }
+
+    #[test]
+    fn test_api_message_role_serialisation() {
+        let role = ApiMessageRole::User;
+        let json = serde_json::to_string(&role).expect("serialise");
+        assert_eq!(json, "\"user\"");
+
+        let role = ApiMessageRole::Assistant;
+        let json = serde_json::to_string(&role).expect("serialise");
+        assert_eq!(json, "\"assistant\"");
+    }
+
+    #[test]
+    fn test_chat_completion_request_serialisation() {
+        let req = ApiChatCompletionRequest {
+            model: "test-model".to_string(),
+            messages: vec![ApiChatMessage {
+                role: ApiMessageRole::User,
+                content: "hello".to_string(),
+            }],
+            temperature: None,
+            max_tokens: None,
+            stream: Some(false),
+        };
+        let json = serde_json::to_string(&req).expect("serialise");
+        assert!(json.contains("\"stream\":false"));
+        assert!(!json.contains("temperature"));
+        assert!(!json.contains("max_tokens"));
+    }
+}

--- a/frontend/src/components/chat.rs
+++ b/frontend/src/components/chat.rs
@@ -75,7 +75,7 @@ pub fn ChatView() -> impl IntoView {
         };
 
         leptos::task::spawn_local(async move {
-            let result = api::send_chat_request(&api_messages, "").await;
+            let result = api::send_chat_request(&api_messages, api::DEFAULT_MODEL).await;
             set_loading.set(false);
 
             let assistant_id = next_id.get();
@@ -116,12 +116,7 @@ pub fn ChatView() -> impl IntoView {
 
     view! {
         <div class="flex-column-full">
-            <MessageList messages />
-            {move || loading.get().then(|| view! {
-                <div class="message-bubble message-assistant message-loading">
-                    "Thinking…"
-                </div>
-            })}
+            <MessageList messages loading />
             <ChatInput on_send disabled=loading />
         </div>
     }
@@ -132,12 +127,18 @@ pub fn ChatView() -> impl IntoView {
 ///
 /// Automatically scrolls to the bottom whenever new messages arrive.
 #[component]
-pub fn MessageList(messages: ReadSignal<Vec<ChatMessage>>) -> impl IntoView {
+pub fn MessageList(
+    messages: ReadSignal<Vec<ChatMessage>>,
+    /// When `true`, a "Thinking…" indicator is shown and the list scrolls to bottom.
+    #[prop(into)]
+    loading: Signal<bool>,
+) -> impl IntoView {
     let scroll_ref: NodeRef<leptos::html::Div> = NodeRef::new();
 
-    // Scroll to bottom whenever the message list changes.
+    // Scroll to bottom whenever the message list changes or loading toggles.
     Effect::new(move |_| {
         let _ = messages.get();
+        let _ = loading.get();
         if let Some(el) = scroll_ref.get() {
             let opts = web_sys::ScrollToOptions::new();
             opts.set_top(el.scroll_height() as f64);
@@ -160,6 +161,11 @@ pub fn MessageList(messages: ReadSignal<Vec<ChatMessage>>) -> impl IntoView {
                     {move || msg.content.clone()}
                 </div>
             </For>
+            {move || loading.get().then(|| view! {
+                <div class="message-bubble message-assistant message-loading">
+                    "Thinking…"
+                </div>
+            })}
         </div>
     }
 }

--- a/frontend/src/components/chat.rs
+++ b/frontend/src/components/chat.rs
@@ -63,6 +63,7 @@ pub fn ChatView() -> impl IntoView {
         let api_messages: Vec<ApiChatMessage> = {
             let msgs = messages.get();
             msgs.iter()
+                .filter(|m| !(m.role == MessageRole::Assistant && m.is_error))
                 .map(|m| ApiChatMessage {
                     role: match m.role {
                         MessageRole::User => ApiMessageRole::User,

--- a/frontend/src/components/chat.rs
+++ b/frontend/src/components/chat.rs
@@ -83,21 +83,27 @@ pub fn ChatView() -> impl IntoView {
 
             match result {
                 Ok(response) => {
-                    let content = response
-                        .choices
-                        .first()
-                        .map(|c| c.message.content.clone())
-                        .unwrap_or_else(|| "(empty response)".to_string());
-
-                    let assistant_msg = ChatMessage {
-                        id: assistant_id,
-                        role: MessageRole::Assistant,
-                        content,
-                        is_error: false,
-                    };
-                    set_messages.update(move |msgs| {
-                        msgs.push(assistant_msg);
-                    });
+                    if let Some(choice) = response.choices.first() {
+                        let assistant_msg = ChatMessage {
+                            id: assistant_id,
+                            role: MessageRole::Assistant,
+                            content: choice.message.content.clone(),
+                            is_error: false,
+                        };
+                        set_messages.update(move |msgs| {
+                            msgs.push(assistant_msg);
+                        });
+                    } else {
+                        let error_msg = ChatMessage {
+                            id: assistant_id,
+                            role: MessageRole::Assistant,
+                            content: "(empty response from model)".to_string(),
+                            is_error: true,
+                        };
+                        set_messages.update(move |msgs| {
+                            msgs.push(error_msg);
+                        });
+                    }
                 }
                 Err(error) => {
                     let error_msg = ChatMessage {

--- a/frontend/src/components/chat.rs
+++ b/frontend/src/components/chat.rs
@@ -44,6 +44,9 @@ pub fn ChatView() -> impl IntoView {
     let next_id = RwSignal::new(0usize);
 
     let on_send = move |text: String| {
+        if loading.get() {
+            return;
+        }
         let user_id = {
             let prev = next_id.get();
             next_id.update(|id| *id += 1);

--- a/frontend/src/components/chat.rs
+++ b/frontend/src/components/chat.rs
@@ -4,7 +4,12 @@
 //! building blocks of the conversation interface. Messages are stored in a
 //! reactive signal (`Vec<ChatMessage>`) inside `ChatView` and flow downward
 //! to `MessageList` for rendering.
+//!
+//! The `ChatView` component connects to the backend via
+//! [`crate::api::send_chat_request`] and manages loading and error states
+//! reactively.
 
+use crate::api::{self, ApiChatMessage, ApiMessageRole};
 use leptos::prelude::*;
 
 /// Role of a participant in a chat conversation.
@@ -20,47 +25,103 @@ pub struct ChatMessage {
     pub id: usize,
     pub role: MessageRole,
     pub content: String,
+    /// When `true`, the message content is an error string and the bubble
+    /// should be styled with the error colour scheme.
+    pub is_error: bool,
 }
 
-/// Top-level chat view that manages conversation history and composes
-/// [`MessageList`] and [`ChatInput`].
+/// Top-level chat view that manages conversation history, loading state, and
+/// composes [`MessageList`] and [`ChatInput`].
 ///
-/// For now, sending a user message immediately appends a simulated
-/// assistant echo response. This will be replaced with a real backend
-/// call once the streaming endpoint is wired in.
+/// On send, the user message is appended to the signal list, a loading state
+/// is set, and [`send_chat_request`] is called. On success the assistant
+/// response is appended and loading cleared; on error an error message bubble
+/// is appended and loading cleared.
 #[component]
 pub fn ChatView() -> impl IntoView {
     let (messages, set_messages) = signal(Vec::<ChatMessage>::new());
+    let (loading, set_loading) = signal(false);
     let next_id = RwSignal::new(0usize);
 
     let on_send = move |text: String| {
-        let get_next = move || {
+        let user_id = {
             let prev = next_id.get();
             next_id.update(|id| *id += 1);
             prev
         };
-        let user_id = get_next();
-        let assistant_id = get_next();
         let user_msg = ChatMessage {
             id: user_id,
             role: MessageRole::User,
             content: text.clone(),
-        };
-        let assistant_msg = ChatMessage {
-            id: assistant_id,
-            role: MessageRole::Assistant,
-            content: format!("Echo: {text}"),
+            is_error: false,
         };
         set_messages.update(move |msgs| {
             msgs.push(user_msg);
-            msgs.push(assistant_msg);
+        });
+        set_loading.set(true);
+
+        let api_messages: Vec<ApiChatMessage> = {
+            let msgs = messages.get();
+            msgs.iter()
+                .map(|m| ApiChatMessage {
+                    role: match m.role {
+                        MessageRole::User => ApiMessageRole::User,
+                        MessageRole::Assistant => ApiMessageRole::Assistant,
+                    },
+                    content: m.content.clone(),
+                })
+                .collect()
+        };
+
+        leptos::task::spawn_local(async move {
+            let result = api::send_chat_request(&api_messages, "").await;
+            set_loading.set(false);
+
+            let assistant_id = next_id.get();
+            next_id.update(|id| *id += 1);
+
+            match result {
+                Ok(response) => {
+                    let content = response
+                        .choices
+                        .first()
+                        .map(|c| c.message.content.clone())
+                        .unwrap_or_else(|| "(empty response)".to_string());
+
+                    let assistant_msg = ChatMessage {
+                        id: assistant_id,
+                        role: MessageRole::Assistant,
+                        content,
+                        is_error: false,
+                    };
+                    set_messages.update(move |msgs| {
+                        msgs.push(assistant_msg);
+                    });
+                }
+                Err(error) => {
+                    let error_msg = ChatMessage {
+                        id: assistant_id,
+                        role: MessageRole::Assistant,
+                        content: format!("{error}"),
+                        is_error: true,
+                    };
+                    set_messages.update(move |msgs| {
+                        msgs.push(error_msg);
+                    });
+                }
+            }
         });
     };
 
     view! {
         <div class="flex-column-full">
             <MessageList messages />
-            <ChatInput on_send />
+            {move || loading.get().then(|| view! {
+                <div class="message-bubble message-assistant message-loading">
+                    "Thinking…"
+                </div>
+            })}
+            <ChatInput on_send disabled=loading />
         </div>
     }
 }
@@ -77,7 +138,7 @@ pub fn MessageList(messages: ReadSignal<Vec<ChatMessage>>) -> impl IntoView {
     Effect::new(move |_| {
         let _ = messages.get();
         if let Some(el) = scroll_ref.get() {
-            let mut opts = web_sys::ScrollToOptions::new();
+            let opts = web_sys::ScrollToOptions::new();
             opts.set_top(el.scroll_height() as f64);
             el.scroll_to_with_scroll_to_options(&opts);
         }
@@ -90,9 +151,10 @@ pub fn MessageList(messages: ReadSignal<Vec<ChatMessage>>) -> impl IntoView {
                 key=|msg: &ChatMessage| msg.id
                 let(msg)
             >
-                <div class={move || match msg.role {
-                    MessageRole::User => "message-bubble message-user",
-                    MessageRole::Assistant => "message-bubble message-assistant",
+                <div class={move || match (&msg.role, msg.is_error) {
+                    (MessageRole::User, _) => "message-bubble message-user",
+                    (MessageRole::Assistant, true) => "message-bubble message-assistant message-error",
+                    (MessageRole::Assistant, false) => "message-bubble message-assistant",
                 }}>
                     {move || msg.content.clone()}
                 </div>
@@ -104,12 +166,16 @@ pub fn MessageList(messages: ReadSignal<Vec<ChatMessage>>) -> impl IntoView {
 /// Input area with a textarea and send button.
 ///
 /// - `Enter` sends the message; `Shift+Enter` inserts a new line.
-/// - The send button is disabled when the input is empty.
+/// - The send button is disabled when the input is empty **or** when the
+///   `disabled` signal is `true` (i.e. a request is in-flight).
 /// - The input field is cleared after sending.
 #[component]
 pub fn ChatInput(
     /// Callback invoked with the message text when the user sends a message.
     on_send: impl Fn(String) + Copy + 'static,
+    /// When `true`, both the textarea and send button are disabled.
+    #[prop(into)]
+    disabled: Signal<bool>,
 ) -> impl IntoView {
     let (input_text, set_input_text) = signal(String::new());
 
@@ -129,7 +195,7 @@ pub fn ChatInput(
         }
     };
 
-    let is_disabled = move || input_text.get().trim().is_empty();
+    let is_send_disabled = move || disabled.get() || input_text.get().trim().is_empty();
 
     view! {
         <div class="sticky-input chat-input-area">
@@ -137,6 +203,7 @@ pub fn ChatInput(
                 class="chat-textarea"
                 placeholder="Type a message…"
                 prop:value=move || input_text.get()
+                disabled=move || disabled.get()
                 on:input:target=move |ev| {
                     set_input_text.set(ev.target().value());
                 }
@@ -144,7 +211,7 @@ pub fn ChatInput(
             ></textarea>
             <button
                 class="send-btn"
-                disabled=is_disabled
+                disabled=is_send_disabled
                 on:click=move |_| handle_send()
             >
                 "Send"

--- a/frontend/src/lib.rs
+++ b/frontend/src/lib.rs
@@ -1,3 +1,4 @@
+mod api;
 mod components;
 
 use components::chat::ChatView;

--- a/frontend/style/main.css
+++ b/frontend/style/main.css
@@ -257,3 +257,35 @@ a:focus-visible {
     width: 100%;
   }
 }
+
+/* --------------------------------------------------------------------------
+   9. Loading & Error States
+   -------------------------------------------------------------------------- */
+
+/* Loading indicator — animated "Thinking…" bubble */
+.message-loading {
+  align-self: flex-start;
+  background-color: var(--color-bg-secondary);
+  color: var(--color-text-secondary);
+  font-style: italic;
+  animation: pulse-opacity 1.4s ease-in-out infinite;
+}
+
+@keyframes pulse-opacity {
+  0%, 100% { opacity: 1; }
+  50%      { opacity: 0.4; }
+}
+
+/* Error messages — left-aligned with error styling */
+.message-error {
+  background-color: #7f1d1d;
+  color: #fecaca;
+  border: 1px solid #991b1b;
+  border-bottom-left-radius: var(--radius-sm);
+}
+
+/* Disabled textarea while request is in-flight */
+.chat-textarea:disabled {
+  opacity: 0.6;
+  cursor: not-allowed;
+}

--- a/frontend/style/main.css
+++ b/frontend/style/main.css
@@ -276,6 +276,14 @@ a:focus-visible {
   50%      { opacity: 0.4; }
 }
 
+/* Respect reduced-motion preference — disable animation for accessibility */
+@media (prefers-reduced-motion: reduce) {
+  .message-loading {
+    animation: none;
+    opacity: 1;
+  }
+}
+
 /* Error messages — left-aligned with error styling */
 .message-error {
   background-color: #7f1d1d;

--- a/server/tests/chat_ui.rs
+++ b/server/tests/chat_ui.rs
@@ -84,9 +84,7 @@ fn test_chat_input_component_defined() {
 fn test_app_uses_chat_view() {
     let source = read_file("frontend/src/lib.rs");
     assert!(
-        Regex::new(r"<ChatView\b")
-            .unwrap()
-            .is_match(&source),
+        Regex::new(r"<ChatView\b").unwrap().is_match(&source),
         "App component must render ChatView"
     );
 }

--- a/server/tests/frontend_api_integration.rs
+++ b/server/tests/frontend_api_integration.rs
@@ -1,0 +1,233 @@
+//! Structural tests for the Leptos frontend API integration (Issue #11).
+//!
+//! These tests verify that the frontend source files contain the expected
+//! module structure, type definitions, and component logic for connecting
+//! the chat UI to the non-streaming backend API.
+
+use regex::Regex;
+use std::path::Path;
+
+/// Returns the normalized workspace root directory.
+fn workspace_root() -> &'static Path {
+    Path::new(env!("CARGO_MANIFEST_DIR")).parent().unwrap()
+}
+
+fn read_file(relative_path: &str) -> String {
+    let path = workspace_root().join(relative_path);
+    assert!(path.exists(), "{relative_path} is missing");
+    std::fs::read_to_string(&path).unwrap_or_else(|e| panic!("failed to read {relative_path}: {e}"))
+}
+
+// ---- API module existence ----
+
+#[test]
+fn test_api_module_file_exists() {
+    let path = workspace_root().join("frontend").join("src").join("api.rs");
+    assert!(path.exists(), "frontend/src/api.rs must exist");
+}
+
+#[test]
+fn test_lib_rs_declares_api_module() {
+    let source = read_file("frontend/src/lib.rs");
+    assert!(
+        Regex::new(r"mod\s+api").unwrap().is_match(&source),
+        "lib.rs must declare `mod api`"
+    );
+}
+
+// ---- API type definitions ----
+
+#[test]
+fn test_api_defines_send_chat_request_function() {
+    let source = read_file("frontend/src/api.rs");
+    assert!(
+        Regex::new(r"pub\s+async\s+fn\s+send_chat_request")
+            .unwrap()
+            .is_match(&source),
+        "api.rs must define a public async function `send_chat_request`"
+    );
+}
+
+#[test]
+fn test_api_defines_api_message_role_enum() {
+    let source = read_file("frontend/src/api.rs");
+    assert!(
+        Regex::new(r"pub\s+enum\s+ApiMessageRole")
+            .unwrap()
+            .is_match(&source),
+        "api.rs must define `pub enum ApiMessageRole`"
+    );
+}
+
+#[test]
+fn test_api_defines_chat_completion_request_struct() {
+    let source = read_file("frontend/src/api.rs");
+    assert!(
+        Regex::new(r"pub\s+struct\s+ApiChatCompletionRequest")
+            .unwrap()
+            .is_match(&source),
+        "api.rs must define `pub struct ApiChatCompletionRequest`"
+    );
+}
+
+#[test]
+fn test_api_defines_chat_completion_response_struct() {
+    let source = read_file("frontend/src/api.rs");
+    assert!(
+        Regex::new(r"pub\s+struct\s+ApiChatCompletionResponse")
+            .unwrap()
+            .is_match(&source),
+        "api.rs must define `pub struct ApiChatCompletionResponse`"
+    );
+}
+
+#[test]
+fn test_api_defines_api_error_enum() {
+    let source = read_file("frontend/src/api.rs");
+    assert!(
+        Regex::new(r"pub\s+enum\s+ApiError")
+            .unwrap()
+            .is_match(&source),
+        "api.rs must define `pub enum ApiError`"
+    );
+}
+
+#[test]
+fn test_api_defines_default_model_constant() {
+    let source = read_file("frontend/src/api.rs");
+    assert!(
+        Regex::new(r"DEFAULT_MODEL").unwrap().is_match(&source),
+        "api.rs must define a DEFAULT_MODEL constant"
+    );
+}
+
+#[test]
+fn test_api_uses_post_method() {
+    let source = read_file("frontend/src/api.rs");
+    assert!(
+        source.contains("POST") || source.contains("post"),
+        "api.rs must use POST HTTP method for chat requests"
+    );
+}
+
+#[test]
+fn test_api_references_chat_completions_endpoint() {
+    let source = read_file("frontend/src/api.rs");
+    assert!(
+        source.contains("/api/chat/completions"),
+        "api.rs must reference the /api/chat/completions endpoint"
+    );
+}
+
+// ---- ChatMessage changes ----
+
+#[test]
+fn test_chat_message_has_is_error_field() {
+    let source = read_file("frontend/src/components/chat.rs");
+    assert!(
+        Regex::new(r"is_error\s*:\s*bool")
+            .unwrap()
+            .is_match(&source),
+        "ChatMessage must have an `is_error: bool` field"
+    );
+}
+
+// ---- ChatView loading state ----
+
+#[test]
+fn test_chat_view_uses_loading_signal() {
+    let source = read_file("frontend/src/components/chat.rs");
+    assert!(
+        Regex::new(r"signal\s*\(\s*false\s*\)")
+            .unwrap()
+            .is_match(&source),
+        "ChatView must initialise a loading signal with `signal(false)`"
+    );
+}
+
+#[test]
+fn test_chat_view_calls_send_chat_request() {
+    let source = read_file("frontend/src/components/chat.rs");
+    assert!(
+        source.contains("send_chat_request"),
+        "ChatView must call send_chat_request from the api module"
+    );
+}
+
+#[test]
+fn test_chat_view_displays_thinking_indicator() {
+    let source = read_file("frontend/src/components/chat.rs");
+    assert!(
+        source.contains("Thinking"),
+        "ChatView must display a 'Thinking' indicator while loading"
+    );
+}
+
+#[test]
+fn test_chat_input_accepts_disabled_prop() {
+    let source = read_file("frontend/src/components/chat.rs");
+    assert!(
+        Regex::new(r"(?s)fn\s+ChatInput\s*\(.*disabled")
+            .unwrap()
+            .is_match(&source),
+        "ChatInput must accept a `disabled` prop"
+    );
+}
+
+#[test]
+fn test_chat_input_disables_textarea_when_loading() {
+    let source = read_file("frontend/src/components/chat.rs");
+    assert!(
+        Regex::new(r"disabled\s*=\s*").unwrap().is_match(&source),
+        "ChatInput textarea must bind the disabled attribute"
+    );
+}
+
+// ---- CSS for error and loading states ----
+
+#[test]
+fn test_css_has_message_error_class() {
+    let css = read_file("frontend/style/main.css");
+    assert!(
+        Regex::new(r"\.message-error\s*\{").unwrap().is_match(&css),
+        "main.css must define .message-error class"
+    );
+}
+
+#[test]
+fn test_css_has_loading_indicator_class() {
+    let css = read_file("frontend/style/main.css");
+    assert!(
+        Regex::new(r"\.message-loading\s*\{")
+            .unwrap()
+            .is_match(&css),
+        "main.css must define .message-loading class"
+    );
+}
+
+#[test]
+fn test_frontend_cargo_toml_has_gloo_net() {
+    let source = read_file("frontend/Cargo.toml");
+    assert!(
+        source.contains("gloo-net"),
+        "frontend/Cargo.toml must include gloo-net dependency"
+    );
+}
+
+#[test]
+fn test_frontend_cargo_toml_has_serde() {
+    let source = read_file("frontend/Cargo.toml");
+    assert!(
+        source.contains("serde"),
+        "frontend/Cargo.toml must include serde dependency"
+    );
+}
+
+#[test]
+fn test_frontend_cargo_toml_has_js_sys() {
+    let source = read_file("frontend/Cargo.toml");
+    assert!(
+        source.contains("js-sys"),
+        "frontend/Cargo.toml must include js-sys dependency for JS interop"
+    );
+}

--- a/server/tests/frontend_api_integration.rs
+++ b/server/tests/frontend_api_integration.rs
@@ -167,7 +167,7 @@ fn test_chat_view_displays_thinking_indicator() {
 fn test_chat_input_accepts_disabled_prop() {
     let source = read_file("frontend/src/components/chat.rs");
     assert!(
-        Regex::new(r"(?s)fn\s+ChatInput\s*\(.*disabled")
+        Regex::new(r"(?s)fn\s+ChatInput\s*\(.*?\bdisabled\b")
             .unwrap()
             .is_match(&source),
         "ChatInput must accept a `disabled` prop"

--- a/server/tests/frontend_api_integration.rs
+++ b/server/tests/frontend_api_integration.rs
@@ -13,6 +13,12 @@ use std::sync::LazyLock;
 /// Locates `pub fn <fn_name>` (or `fn <fn_name>`), then counts braces to
 /// find the matching closing `}` and returns the text between the braces.
 /// Returns `None` if the function cannot be found or braces are unbalanced.
+///
+/// **Limitation:** This function counts raw braces and does not skip braces
+/// inside string literals (`"..."`), char literals (`...`), line comments
+/// (`// ...`), or block comments (`/* ... */`). Bodies containing such
+/// constructs may be parsed incorrectly. For more robust extraction, use a
+/// proper parser such as `syn`.
 fn extract_function_body(source: &str, fn_name: &str) -> Option<String> {
     let pattern = format!(r"(?m)^(?:pub\s+)?fn\s+{}\s*[\(<]", regex::escape(fn_name));
     let re = Regex::new(&pattern).ok()?;
@@ -193,11 +199,11 @@ fn test_chat_message_has_is_error_field() {
 fn test_chat_view_uses_loading_signal() {
     let source = read_file("frontend/src/components/chat.rs");
     assert!(
-        Regex::new(r"signal\s*\(\s*false\s*\)").unwrap().is_match(
+        Regex::new(r"let\s*\(.*\bloading\b.*\).*signal\s*\(\s*false\s*\)").unwrap().is_match(
             &extract_function_body(&source, "ChatView")
                 .expect("ChatView function must exist in chat.rs"),
         ),
-        "ChatView must initialise a loading signal with `signal(false)`"
+        "ChatView must declare `let (loading, …) = signal(false)`"
     );
 }
 

--- a/server/tests/frontend_api_integration.rs
+++ b/server/tests/frontend_api_integration.rs
@@ -5,11 +5,32 @@
 //! the chat UI to the non-streaming backend API.
 
 use regex::Regex;
-use std::path::Path;
+use std::path::{Path, PathBuf};
+use std::sync::LazyLock;
 
 /// Returns the normalized workspace root directory.
 fn workspace_root() -> &'static Path {
-    Path::new(env!("CARGO_MANIFEST_DIR")).parent().unwrap()
+    static WORKSPACE_ROOT: LazyLock<PathBuf> = LazyLock::new(|| {
+        let manifest_dir = env!("CARGO_MANIFEST_DIR");
+        let mut dir = Path::new(manifest_dir);
+        loop {
+            let candidate = dir.join("Cargo.toml");
+            if candidate.exists() {
+                if let Ok(contents) = std::fs::read_to_string(&candidate) {
+                    if contents.contains("[workspace]") {
+                        return dir.to_path_buf();
+                    }
+                }
+            }
+            dir = dir.parent().unwrap_or_else(|| {
+                panic!(
+                    "could not find workspace Cargo.toml above {}",
+                    manifest_dir
+                )
+            });
+        }
+    });
+    &WORKSPACE_ROOT
 }
 
 fn read_file(relative_path: &str) -> String {
@@ -167,7 +188,7 @@ fn test_chat_view_displays_thinking_indicator() {
 fn test_chat_input_accepts_disabled_prop() {
     let source = read_file("frontend/src/components/chat.rs");
     assert!(
-        Regex::new(r"(?s)fn\s+ChatInput\s*\(.*?\bdisabled\b")
+        Regex::new(r"fn\s+ChatInput\s*\((?:[^)]|\([^)]*\))*\bdisabled\b")
             .unwrap()
             .is_match(&source),
         "ChatInput must accept a `disabled` prop"
@@ -178,7 +199,9 @@ fn test_chat_input_accepts_disabled_prop() {
 fn test_chat_input_disables_textarea_when_loading() {
     let source = read_file("frontend/src/components/chat.rs");
     assert!(
-        Regex::new(r"disabled\s*=\s*").unwrap().is_match(&source),
+        Regex::new(r"<textarea[^>]*\bdisabled\s*=")
+            .unwrap()
+            .is_match(&source),
         "ChatInput textarea must bind the disabled attribute"
     );
 }

--- a/server/tests/frontend_api_integration.rs
+++ b/server/tests/frontend_api_integration.rs
@@ -8,6 +8,40 @@ use regex::Regex;
 use std::path::{Path, PathBuf};
 use std::sync::LazyLock;
 
+/// Extracts the body of a top-level function named `fn_name` from `source`.
+///
+/// Locates `pub fn <fn_name>` (or `fn <fn_name>`), then counts braces to
+/// find the matching closing `}` and returns the text between the braces.
+/// Returns `None` if the function cannot be found or braces are unbalanced.
+fn extract_function_body(source: &str, fn_name: &str) -> Option<String> {
+    let pattern = format!(r"(?m)^(?:pub\s+)?fn\s+{}\s*[\(<]", regex::escape(fn_name));
+    let re = Regex::new(&pattern).ok()?;
+    let mat = re.find(source)?;
+    let start = mat.start();
+
+    let after_sig = &source[start..];
+    let brace_pos = after_sig.find('{')?;
+    let body_start = start + brace_pos + 1;
+
+    let mut depth = 1i32;
+    let mut pos = body_start;
+    let bytes = source.as_bytes();
+    while pos < bytes.len() && depth > 0 {
+        match bytes[pos] {
+            b'{' => depth += 1,
+            b'}' => depth -= 1,
+            _ => {}
+        }
+        pos += 1;
+    }
+
+    if depth == 0 {
+        Some(source[body_start..pos - 1].to_string())
+    } else {
+        None
+    }
+}
+
 /// Returns the normalized workspace root directory.
 fn workspace_root() -> &'static Path {
     static WORKSPACE_ROOT: LazyLock<PathBuf> = LazyLock::new(|| {
@@ -159,9 +193,10 @@ fn test_chat_message_has_is_error_field() {
 fn test_chat_view_uses_loading_signal() {
     let source = read_file("frontend/src/components/chat.rs");
     assert!(
-        Regex::new(r"signal\s*\(\s*false\s*\)")
-            .unwrap()
-            .is_match(&source),
+        Regex::new(r"signal\s*\(\s*false\s*\)").unwrap().is_match(
+            &extract_function_body(&source, "ChatView")
+                .expect("ChatView function must exist in chat.rs"),
+        ),
         "ChatView must initialise a loading signal with `signal(false)`"
     );
 }
@@ -169,18 +204,22 @@ fn test_chat_view_uses_loading_signal() {
 #[test]
 fn test_chat_view_calls_send_chat_request() {
     let source = read_file("frontend/src/components/chat.rs");
+    let body = extract_function_body(&source, "ChatView")
+        .expect("ChatView function must exist in chat.rs");
     assert!(
-        source.contains("send_chat_request"),
-        "ChatView must call send_chat_request from the api module"
+        body.contains("send_chat_request(") || body.contains("api::send_chat_request("),
+        "ChatView body must call send_chat_request() from the api module"
     );
 }
 
 #[test]
 fn test_chat_view_displays_thinking_indicator() {
     let source = read_file("frontend/src/components/chat.rs");
+    let body = extract_function_body(&source, "MessageList")
+        .expect("MessageList function must exist in chat.rs");
     assert!(
-        source.contains("Thinking"),
-        "ChatView must display a 'Thinking' indicator while loading"
+        body.contains("\"Thinking"),
+        "MessageList body must contain the 'Thinking' text indicator"
     );
 }
 

--- a/wiki/frontend-api-integration.md
+++ b/wiki/frontend-api-integration.md
@@ -1,0 +1,99 @@
+# Frontend API Integration — Feature Guide
+
+## Overview
+
+The chat interface now connects to the real AI backend. When you send a message, it goes to the LibreChat server, which forwards it to the configured LLM (e.g. Ollama running locally). The assistant's response appears in the chat once the model finishes generating it.
+
+This replaces the previous "Echo" placeholder with actual AI-powered responses.
+
+## How to Use
+
+1. **Make sure the backend is running** — start the server with `cargo run` (it defaults to `http://localhost:3000`).
+2. **Make sure an LLM is available** — e.g. run `ollama serve` and pull a model like `llama3`.
+3. **Open the app** in your browser at `http://localhost:3000`.
+4. **Type a message** and press **Enter** or click **Send**.
+5. While the AI is thinking, you'll see a "Thinking…" indicator with a pulsing animation.
+6. Once the response arrives, the assistant's reply appears as a message bubble.
+7. If something goes wrong (network error, server down), an error message appears in a red bubble.
+
+## What Changed
+
+| Before | After |
+|--------|-------|
+| Messages echoed back as "Echo: …" | Messages sent to the AI backend |
+| No loading indicator | "Thinking…" pulsing indicator shown while waiting |
+| Send button always enabled | Send button and textarea disabled during requests |
+| No error handling | Network/HTTP errors shown in red bubbles |
+
+## Visual Layout (Updated)
+
+```text
+┌─────────────────────────────────┐
+│                                 │
+│  [Your message]                 │
+│                                 │
+│  [AI response]                  │
+│                                 │
+│  ┌─ Thinking… ───────────────┐ │  ← pulsing animation while loading
+│  └────────────────────────────┘ │
+│                                 │
+│  ┌─ ⚠ Network error: … ─────┐ │  ← red bubble on error
+│  └────────────────────────────┘ │
+│                                 │
+├─────────────────────────────────┤
+│ [Type a message…        ] [Send]│  ← both disabled during request
+└─────────────────────────────────┘
+```
+
+## Configuring the API URL
+
+By default, the frontend sends requests to the same server that serves the page (relative URLs). This works when both are on the same origin.
+
+To override the API base URL, set a JavaScript global before the WASM module loads:
+
+```html
+<script>
+  window.__LIBRECHAT_API_URL__ = "http://192.168.1.100:3000";
+</script>
+```
+
+This is useful for development or when the frontend and backend are served from different origins.
+
+## Changing the Default Model
+
+The frontend sends `"llama3"` as the default model. To use a different model, change the `DEFAULT_MODEL` constant in `frontend/src/api.rs`:
+
+```rust
+pub const DEFAULT_MODEL: &str = "mistral";  // or any model your Ollama instance supports
+```
+
+## Glossary
+
+| Term | Meaning |
+|------|---------|
+| **Non-streaming** | The full response is sent at once (not token-by-token) |
+| **Ollama** | A local LLM runtime that serves OpenAI-compatible APIs |
+| **CORS** | Cross-Origin Resource Sharing — browser security feature |
+| **WASM** | WebAssembly — how Rust code runs directly in the browser |
+
+## FAQ / Troubleshooting
+
+**I see "Network error: …" in the chat.**
+- Make sure the backend server is running (`cargo run`).
+- Check that the API URL is correct. If you're accessing the frontend from a different host, set `window.__LIBRECHAT_API_URL__`.
+- Ensure Ollama is running: `ollama serve`.
+
+**I see "HTTP 502: …" in the chat.**
+- The backend couldn't reach the LLM provider. Verify Ollama is running and the model is available: `ollama list`.
+
+**The "Thinking…" indicator never goes away.**
+- The request may have hung. Check the browser's Network tab and the server logs for errors.
+
+**The textarea and Send button stay disabled.**
+- This should only happen while a request is in-flight. If the request failed and the controls are still disabled, it's a bug — please file an issue.
+
+## Related Resources
+
+- Technical documentation: [`docs/frontend-api-integration.md`](../docs/frontend-api-integration.md)
+- Chat UI feature: [`wiki/chat-ui.md`](chat-ui.md)
+- Backend chat completions: [`wiki/chat-completions-route.md`](chat-completions-route.md)


### PR DESCRIPTION
Closes #11

## Summary

Connects the Leptos CSR frontend to the backend non-streaming chat completions endpoint (`POST /api/chat/completions`).

### Changes

**Frontend API Client** (`frontend/src/api.rs`):
- `send_chat_request` — async function that POSTs conversation history to the backend
- `ApiError` — error enum covering Network, HTTP, and Parse failures
- API types mirror the server's `ChatCompletionRequest`/`ChatCompletionResponse`
- `DEFAULT_MODEL` constant (`llama3`)
- `api_base_url()` reads `window.__LIBRECHAT_API_URL__` for configurable API URL

**ChatView** updates (`frontend/src/components/chat.rs`):
- Replaces echo simulation with real backend API call via `spawn_local`
- Adds `loading` signal — shows pulsing "Thinking..." indicator while request is in-flight
- Adds `is_error` field to `ChatMessage` — error responses display in red-styled bubbles
- Disables textarea and send button during in-flight requests
- Converts conversation messages to API format before sending

**CSS** (`frontend/style/main.css`):
- `.message-loading` — pulsing opacity animation for the "Thinking..." indicator
- `.message-error` — red background/border styling for error message bubbles
- `.chat-textarea:disabled` — reduced opacity and cursor styling for in-flight state

**Dependencies** (`frontend/Cargo.toml`):
- Added `gloo-net` (0.6, with json feature) for WASM HTTP requests
- Added `serde` and `serde_json` (workspace) for JSON serialisation
- Added `js-sys` (0.3) for JavaScript interop
- Added `Window` feature to `web-sys`

**Tests** (`server/tests/frontend_api_integration.rs`):
- 21 structural tests verifying module existence, type definitions, component props, and CSS classes

**Documentation**:
- `docs/frontend-api-integration.md` — technical documentation
- `wiki/frontend-api-integration.md` — user-facing feature guide

### Acceptance Criteria

- [x] Sending a message in the UI calls `POST /api/chat/completions`
- [x] The assistant message bubble updates with the full response text
- [x] The send button and textarea are disabled while the request is in-flight
- [x] Network errors display an error message in the assistant bubble
- [x] Works with Ollama running locally via the backend proxy

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Chat now sends real non‑streaming requests to the backend, shows assistant replies or red error bubbles, and disables input while awaiting responses.

* **Style**
  * Added visual styles for loading pulses, “Thinking…” bubble and error message bubbles; disabled textarea is visually dimmed.

* **Documentation**
  * New user guide for frontend‑to‑backend chat integration and troubleshooting.

* **Tests**
  * Automated checks validating frontend chat API integration and UI behaviours.

* **Chores**
  * Frontend package version bumped and build dependencies updated.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->