### PR TITLE
feat: redesign chat UI with sidebar, settings, and dynamic model list

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -46,3 +46,6 @@ A "unit of work" is defined as any committable amount of work. For every unit of
 
 ## Resource Constraints Note
 Since this project targets Raspberry Pi and legacy hardware, avoid adding "heavy" dependencies. Every new crate must be evaluated for its impact on binary size and runtime memory overhead.
+
+## Branch Naming
+- Do NOT name branches starting with 'codex'. Use descriptive names like 'feat/ui-redesign' or 'fix/streaming-bug'.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -511,7 +511,7 @@ dependencies = [
 
 [[package]]
 name = "frontend"
-version = "0.5.0"
+version = "0.5.1"
 dependencies = [
  "gloo-net",
  "js-sys",
@@ -1993,7 +1993,7 @@ dependencies = [
 
 [[package]]
 name = "server"
-version = "0.10.0"
+version = "0.10.1"
 dependencies = [
  "async-trait",
  "axum",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -511,7 +511,7 @@ dependencies = [
 
 [[package]]
 name = "frontend"
-version = "0.4.0"
+version = "0.5.0"
 dependencies = [
  "gloo-net",
  "js-sys",
@@ -1993,7 +1993,7 @@ dependencies = [
 
 [[package]]
 name = "server"
-version = "0.9.0"
+version = "0.10.0"
 dependencies = [
  "async-trait",
  "axum",

--- a/frontend/Cargo.toml
+++ b/frontend/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "frontend"
-version = "0.4.0"
+version = "0.5.0"
 edition = "2021"
 
 [dependencies]
@@ -10,7 +10,16 @@ serde = { workspace = true }
 serde_json = { workspace = true }
 gloo-net = { version = "0.6", features = ["json"] }
 js-sys = "0.3"
-web-sys = { version = "0.3", features = ["KeyboardEvent", "HtmlDivElement", "ScrollToOptions", "Element", "HtmlTextAreaElement", "Window"] }
+web-sys = { version = "0.3", features = [
+    "KeyboardEvent",
+    "HtmlDivElement",
+    "HtmlSelectElement",
+    "HtmlInputElement",
+    "ScrollToOptions",
+    "Element",
+    "HtmlTextAreaElement",
+    "Window",
+] }
 
 [lib]
 crate-type = ["cdylib", "rlib"]

--- a/frontend/Cargo.toml
+++ b/frontend/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "frontend"
-version = "0.5.0"
+version = "0.5.1"
 edition = "2021"
 
 [dependencies]

--- a/frontend/src/api.rs
+++ b/frontend/src/api.rs
@@ -307,12 +307,4 @@ mod tests {
         );
     }
 
-    #[cfg(target_arch = "wasm32")]
-    #[test]
-    fn test_resolve_api_base_empty_falls_back() {
-        // Without a browser window, the JS fallback returns empty string.
-        let result = resolve_api_base("");
-        // We can't assert the JS value in unit tests, but we verify it doesn't panic.
-        assert!(result.is_empty() || result.starts_with("http"));
-    }
 }

--- a/frontend/src/api.rs
+++ b/frontend/src/api.rs
@@ -1,9 +1,8 @@
-//! Frontend API client for the LibreChat non-streaming chat endpoint.
+//! Frontend API client for the LibreChat chat and models endpoints.
 //!
-//! Provides [`send_chat_request`] which posts a conversation history to the
-//! backend `POST /api/chat/completions` endpoint and returns the full
-//! [`ApiChatCompletionResponse`]. The API base URL is configurable via the
-//! `window.__LIBRECHAT_API_URL__` JavaScript property (default: current origin).
+//! Provides [`send_chat_request`] and [`fetch_models`] which communicate with
+//! the backend. The API base URL and optional auth key are read from the
+//! application state settings rather than hardcoded constants.
 
 use gloo_net::http::Request;
 use serde::{Deserialize, Serialize};
@@ -41,10 +40,6 @@ pub struct ApiChatCompletionRequest {
 }
 
 /// Non-streaming response received from the chat completions endpoint.
-///
-/// Fields `id`, `model`, and `usage` are deserialized from the server response
-/// but not yet consumed by the frontend — they are kept to maintain a
-/// complete API contract for future use.
 #[allow(dead_code)]
 #[derive(Debug, Clone, Deserialize)]
 pub struct ApiChatCompletionResponse {
@@ -55,8 +50,6 @@ pub struct ApiChatCompletionResponse {
 }
 
 /// A single completion choice in a non-streaming response.
-///
-/// Fields `index` and `finish_reason` are kept for API completeness.
 #[allow(dead_code)]
 #[derive(Debug, Clone, Deserialize)]
 pub struct ApiChoice {
@@ -66,8 +59,6 @@ pub struct ApiChoice {
 }
 
 /// Token usage statistics returned by the provider.
-///
-/// Kept for API completeness; not yet displayed in the UI.
 #[allow(dead_code)]
 #[derive(Debug, Clone, Deserialize)]
 pub struct ApiUsage {
@@ -76,7 +67,19 @@ pub struct ApiUsage {
     pub total_tokens: u32,
 }
 
-/// Errors that can occur when calling the chat completions API.
+/// A single model returned by the `/api/models` endpoint.
+#[derive(Debug, Clone, Deserialize)]
+pub struct ApiModelInfo {
+    pub id: String,
+}
+
+/// Response from the `/api/models` endpoint.
+#[derive(Debug, Clone, Deserialize)]
+pub struct ApiModelsResponse {
+    pub models: Vec<ApiModelInfo>,
+}
+
+/// Errors that can occur when calling the API.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum ApiError {
     /// The network request failed (e.g. CORS, DNS, connection refused).
@@ -97,11 +100,20 @@ impl std::fmt::Display for ApiError {
     }
 }
 
+/// Resolve the full API base URL. If the user has configured a custom
+/// endpoint in settings, that is used. Otherwise falls back to the
+/// `window.__LIBRECHAT_API_URL__` JS property (empty string = same origin).
+fn resolve_api_base(custom_endpoint: &str) -> String {
+    if !custom_endpoint.is_empty() {
+        return custom_endpoint.trim_end_matches('/').to_string();
+    }
+    js_api_base_url()
+}
+
 /// Read the API base URL from the `window.__LIBRECHAT_API_URL__` JavaScript
 /// property. Returns an empty string (i.e. relative URLs) when the property
-/// is not set, which works correctly when the frontend is served by the same
-/// origin as the backend.
-fn api_base_url() -> String {
+/// is not set.
+fn js_api_base_url() -> String {
     use web_sys::window;
 
     let Some(win) = window() else {
@@ -118,16 +130,34 @@ fn api_base_url() -> String {
     value.as_string().unwrap_or_default()
 }
 
+/// Build a `RequestBuilder` with optional `Authorization: Bearer` header.
+fn builder_with_auth(method: &str, url: &str, auth_key: &str) -> gloo_net::http::RequestBuilder {
+    let builder = match method {
+        "GET" => Request::get(url),
+        "POST" => Request::post(url),
+        _ => panic!("Unsupported HTTP method: {method}"),
+    };
+
+    if !auth_key.is_empty() {
+        builder.header("Authorization", &format!("Bearer {auth_key}"))
+    } else {
+        builder
+    }
+}
+
 /// Send a non-streaming chat completion request to the backend.
 ///
 /// Constructs a `POST /api/chat/completions` request with the given messages
 /// and model, then awaits the full response. The model defaults to
-/// [`DEFAULT_MODEL`] when an empty string is supplied.
+/// [`DEFAULT_MODEL`] when an empty string is supplied. The `endpoint` and
+/// `auth_key` parameters override the default origin and add auth headers.
 pub async fn send_chat_request(
     messages: &[ApiChatMessage],
     model: &str,
+    endpoint: &str,
+    auth_key: &str,
 ) -> Result<ApiChatCompletionResponse, ApiError> {
-    let base = api_base_url();
+    let base = resolve_api_base(endpoint);
     let url = format!("{base}/api/chat/completions");
 
     let request = ApiChatCompletionRequest {
@@ -142,7 +172,7 @@ pub async fn send_chat_request(
         stream: Some(false),
     };
 
-    let response = Request::post(&url)
+    let response = builder_with_auth("POST", &url, auth_key)
         .json(&request)
         .map_err(|e| ApiError::Network(e.to_string()))?
         .send()
@@ -166,6 +196,40 @@ pub async fn send_chat_request(
         .json()
         .await
         .map_err(|e| ApiError::Parse(e.to_string()))
+}
+
+/// Fetch the list of available models from the backend.
+///
+/// Calls `GET /api/models` and returns the model identifiers. The `endpoint`
+/// and `auth_key` parameters override the default origin and add auth headers.
+pub async fn fetch_models(endpoint: &str, auth_key: &str) -> Result<Vec<ApiModelInfo>, ApiError> {
+    let base = resolve_api_base(endpoint);
+    let url = format!("{base}/api/models");
+
+    let response = builder_with_auth("GET", &url, auth_key)
+        .send()
+        .await
+        .map_err(|e| ApiError::Network(e.to_string()))?;
+
+    let status = response.status();
+
+    if !response.ok() {
+        let body = response
+            .text()
+            .await
+            .unwrap_or_else(|_| "<no body>".to_string());
+        return Err(ApiError::Http {
+            status,
+            body: body.chars().take(512).collect(),
+        });
+    }
+
+    let models_response: ApiModelsResponse = response
+        .json()
+        .await
+        .map_err(|e| ApiError::Parse(e.to_string()))?;
+
+    Ok(models_response.models)
 }
 
 #[cfg(test)]
@@ -225,5 +289,30 @@ mod tests {
         assert!(json.contains("\"stream\":false"));
         assert!(!json.contains("temperature"));
         assert!(!json.contains("max_tokens"));
+    }
+
+    #[test]
+    fn test_resolve_api_base_uses_custom_endpoint() {
+        assert_eq!(
+            resolve_api_base("http://localhost:11434"),
+            "http://localhost:11434"
+        );
+    }
+
+    #[test]
+    fn test_resolve_api_base_strips_trailing_slash() {
+        assert_eq!(
+            resolve_api_base("http://localhost:11434/"),
+            "http://localhost:11434"
+        );
+    }
+
+    #[cfg(target_arch = "wasm32")]
+    #[test]
+    fn test_resolve_api_base_empty_falls_back() {
+        // Without a browser window, the JS fallback returns empty string.
+        let result = resolve_api_base("");
+        // We can't assert the JS value in unit tests, but we verify it doesn't panic.
+        assert!(result.is_empty() || result.starts_with("http"));
     }
 }

--- a/frontend/src/components/chat.rs
+++ b/frontend/src/components/chat.rs
@@ -40,6 +40,8 @@ pub fn ModelSelector() -> impl IntoView {
     let (custom_input, set_custom_input) = signal(false);
 
     // Refresh models on mount.
+    // Note: Effect::new with no tracked signal reads runs exactly once on mount,
+    // so state.refresh_models() is invoked only at component creation, not on every render.
     Effect::new(move |_| {
         state.refresh_models();
     });
@@ -100,7 +102,7 @@ pub fn ModelSelector() -> impl IntoView {
                     >
                         {
                             let id = model.id.clone();
-                            let id_display = model.id.clone();
+                            let id_display = id.clone();
                             let id_selected = model.id.clone();
                             view! {
                                 <option value=move || id.clone() selected=move || state.selected_model.get() == id_selected>
@@ -139,10 +141,7 @@ pub fn ChatView() -> impl IntoView {
     let next_id = RwSignal::new(0usize);
 
     let active_messages = move || {
-        state
-            .active_thread()
-            .map(|t| t.messages)
-            .unwrap_or_default()
+        state.active_messages()
     };
 
     let on_send = move |text: String| {
@@ -181,8 +180,9 @@ pub fn ChatView() -> impl IntoView {
             if let Some(thread) = threads.iter_mut().find(|t| t.id == active_id) {
                 thread.messages.push(user_msg);
                 if is_first_message {
-                    let title = if text.len() > 30 {
-                        format!("{}…", &text[..30])
+                    let title = if text.chars().count() > 30 {
+                        let truncated: String = text.chars().take(30).collect();
+                        format!("{truncated}…")
                     } else {
                         text.clone()
                     };

--- a/frontend/src/components/chat.rs
+++ b/frontend/src/components/chat.rs
@@ -1,16 +1,14 @@
 //! Chat UI components for the LibreChat frontend.
 //!
-//! Provides [`ChatView`], [`MessageList`], and [`ChatInput`] — the core
-//! building blocks of the conversation interface. Messages are stored in a
-//! reactive signal (`Vec<ChatMessage>`) inside `ChatView` and flow downward
-//! to `MessageList` for rendering.
-//!
-//! The `ChatView` component connects to the backend via
-//! [`crate::api::send_chat_request`] and manages loading and error states
-//! reactively.
+//! Provides [`ChatView`], [`MessageList`], [`ChatInput`], and [`ModelSelector`]
+//! — the core building blocks of the conversation interface. Messages are
+//! stored per-thread in the global [`AppState`] and the active thread is
+//! switched via the sidebar.
 
 use crate::api::{self, ApiChatMessage, ApiMessageRole};
+use crate::state::AppState;
 use leptos::prelude::*;
+use wasm_bindgen::JsCast;
 
 /// Role of a participant in a chat conversation.
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
@@ -30,103 +28,254 @@ pub struct ChatMessage {
     pub is_error: bool,
 }
 
-/// Top-level chat view that manages conversation history, loading state, and
-/// composes [`MessageList`] and [`ChatInput`].
+/// Model selector dropdown displayed in the chat header.
 ///
-/// On send, the user message is appended to the signal list, a loading state
-/// is set, and [`send_chat_request`] is called. On success the assistant
-/// response is appended and loading cleared; on error an error message bubble
-/// is appended and loading cleared.
+/// Fetches the available model list from the configured provider and allows
+/// the user to select a model or enter a custom model name. The selected
+/// model is stored in global state and applies to all new chat requests
+/// unless changed.
+#[component]
+pub fn ModelSelector() -> impl IntoView {
+    let state = AppState::expect();
+    let (custom_input, set_custom_input) = signal(false);
+
+    // Refresh models on mount.
+    Effect::new(move |_| {
+        state.refresh_models();
+    });
+
+    let on_select_change = move |ev: web_sys::Event| {
+        let target: web_sys::HtmlSelectElement = ev.target().unwrap().unchecked_into();
+        let value = target.value();
+        if value == "__custom" {
+            set_custom_input.set(true);
+        } else {
+            set_custom_input.set(false);
+            state.selected_model.set(value);
+        }
+    };
+
+    let on_custom_change = move |ev: web_sys::Event| {
+        let target: web_sys::HtmlInputElement = ev.target().unwrap().unchecked_into();
+        let value = target.value();
+        state.selected_model.set(value);
+    };
+
+    view! {
+        <div class="model-selector">
+            <Show
+                when=move || !custom_input.get()
+                fallback=move || view! {
+                    <div class="model-custom-input">
+                        <input
+                            class="form-input model-input"
+                            type="text"
+                            placeholder="Model name…"
+                            prop:value=move || state.selected_model.get()
+                            on:input=on_custom_change
+                        />
+                        <button
+                            class="model-back-btn"
+                            on:click=move |_| set_custom_input.set(false)
+                            aria-label="Back to presets"
+                        >
+                            "←"
+                        </button>
+                    </div>
+                }
+            >
+                <select
+                    class="model-select"
+                    prop:value=move || state.selected_model.get()
+                    on:change=on_select_change
+                    aria-label="Select model"
+                >
+                    <Show when=move || state.models_loading.get() fallback=|| ()>
+                        <option value="" disabled=true>"Loading models…"</option>
+                    </Show>
+                    <For
+                        each=move || state.available_models.get()
+                        key=|model| model.id.clone()
+                        let(model)
+                    >
+                        {
+                            let id = model.id.clone();
+                            let id_display = model.id.clone();
+                            let id_selected = model.id.clone();
+                            view! {
+                                <option value=move || id.clone() selected=move || state.selected_model.get() == id_selected>
+                                    {move || id_display.clone()}
+                                </option>
+                            }
+                        }
+                    </For>
+                    <option value="__custom">"Custom…"</option>
+                </select>
+            </Show>
+            <Show when=move || state.models_error.get().is_some()>
+                <span class="model-error-hint" title=move || state.models_error.get().unwrap_or_default()>
+                    "⚠"
+                </span>
+            </Show>
+        </div>
+    }
+}
+
+/// Top-level chat view that manages the active thread's conversation,
+/// loading state, and composes [`ModelSelector`], [`MessageList`] and
+/// [`ChatInput`].
+///
+/// On send, the user message is appended to the active thread, a loading
+/// state is set, and [`send_chat_request`] is called. On success the
+/// assistant response is appended and loading cleared; on error an error
+/// message bubble is appended and loading cleared.
+///
+/// If no thread is active, a welcome screen is shown with a prompt to
+/// start a chat.
 #[component]
 pub fn ChatView() -> impl IntoView {
-    let (messages, set_messages) = signal(Vec::<ChatMessage>::new());
+    let state = AppState::expect();
     let (loading, set_loading) = signal(false);
     let next_id = RwSignal::new(0usize);
+
+    let active_messages = move || {
+        state
+            .active_thread()
+            .map(|t| t.messages)
+            .unwrap_or_default()
+    };
 
     let on_send = move |text: String| {
         if loading.get() {
             return;
         }
+
+        // Ensure there is an active thread.
+        if state.active_thread_id.get().is_none() {
+            state.create_thread();
+        }
+
+        let active_id = state.active_thread_id.get().unwrap();
+
         let user_id = {
             let prev = next_id.get();
             next_id.update(|id| *id += 1);
             prev
         };
+
         let user_msg = ChatMessage {
             id: user_id,
             role: MessageRole::User,
             content: text.clone(),
             is_error: false,
         };
-        set_messages.update(move |msgs| {
-            msgs.push(user_msg);
+
+        // Update the thread's first message as the title.
+        let is_first_message = {
+            let threads = state.threads.get();
+            let thread = threads.iter().find(|t| t.id == active_id);
+            thread.is_none_or(|t| t.messages.is_empty())
+        };
+
+        state.threads.update(|threads| {
+            if let Some(thread) = threads.iter_mut().find(|t| t.id == active_id) {
+                thread.messages.push(user_msg);
+                if is_first_message {
+                    let title = if text.len() > 30 {
+                        format!("{}…", &text[..30])
+                    } else {
+                        text.clone()
+                    };
+                    thread.title = title;
+                }
+            }
         });
+
         set_loading.set(true);
 
         let api_messages: Vec<ApiChatMessage> = {
-            let msgs = messages.get();
-            msgs.iter()
-                .filter(|m| !(m.role == MessageRole::Assistant && m.is_error))
-                .map(|m| ApiChatMessage {
-                    role: match m.role {
-                        MessageRole::User => ApiMessageRole::User,
-                        MessageRole::Assistant => ApiMessageRole::Assistant,
-                    },
-                    content: m.content.clone(),
+            let threads = state.threads.get();
+            let thread = threads.iter().find(|t| t.id == active_id);
+            thread
+                .map(|t| {
+                    t.messages
+                        .iter()
+                        .filter(|m| !(m.role == MessageRole::Assistant && m.is_error))
+                        .map(|m| ApiChatMessage {
+                            role: match m.role {
+                                MessageRole::User => ApiMessageRole::User,
+                                MessageRole::Assistant => ApiMessageRole::Assistant,
+                            },
+                            content: m.content.clone(),
+                        })
+                        .collect()
                 })
-                .collect()
+                .unwrap_or_default()
         };
 
+        let model = state.selected_model.get();
+        let settings = state.settings.get();
+        let endpoint = settings.api_endpoint.clone();
+        let auth_key = settings.auth_key.clone();
+
         leptos::task::spawn_local(async move {
-            let result = api::send_chat_request(&api_messages, api::DEFAULT_MODEL).await;
+            let result = api::send_chat_request(&api_messages, &model, &endpoint, &auth_key).await;
             set_loading.set(false);
 
             let assistant_id = next_id.get();
             next_id.update(|id| *id += 1);
 
-            match result {
+            let assistant_msg = match result {
                 Ok(response) => {
                     if let Some(choice) = response.choices.first() {
-                        let assistant_msg = ChatMessage {
+                        ChatMessage {
                             id: assistant_id,
                             role: MessageRole::Assistant,
                             content: choice.message.content.clone(),
                             is_error: false,
-                        };
-                        set_messages.update(move |msgs| {
-                            msgs.push(assistant_msg);
-                        });
+                        }
                     } else {
-                        let error_msg = ChatMessage {
+                        ChatMessage {
                             id: assistant_id,
                             role: MessageRole::Assistant,
                             content: "(empty response from model)".to_string(),
                             is_error: true,
-                        };
-                        set_messages.update(move |msgs| {
-                            msgs.push(error_msg);
-                        });
+                        }
                     }
                 }
-                Err(error) => {
-                    let error_msg = ChatMessage {
-                        id: assistant_id,
-                        role: MessageRole::Assistant,
-                        content: format!("{error}"),
-                        is_error: true,
-                    };
-                    set_messages.update(move |msgs| {
-                        msgs.push(error_msg);
-                    });
+                Err(error) => ChatMessage {
+                    id: assistant_id,
+                    role: MessageRole::Assistant,
+                    content: format!("{error}"),
+                    is_error: true,
+                },
+            };
+
+            state.threads.update(|threads| {
+                if let Some(thread) = threads.iter_mut().find(|t| t.id == active_id) {
+                    thread.messages.push(assistant_msg);
                 }
-            }
+            });
         });
     };
 
     view! {
         <div class="flex-column-full">
-            <MessageList messages loading />
-            <ChatInput on_send disabled=loading />
+            <div class="chat-header">
+                <ModelSelector />
+            </div>
+            <Show
+                when=move || state.active_thread_id.get().is_some()
+                fallback=|| view! {
+                    <div class="chat-welcome">
+                        <h1 class="welcome-title">"LibreChat"</h1>
+                        <p class="welcome-subtitle">"Start a conversation or select a thread from the sidebar."</p>
+                    </div>
+                }
+            >
+                <MessageList messages=active_messages loading />
+                <ChatInput on_send disabled=loading />
+            </Show>
         </div>
     }
 }
@@ -137,16 +286,14 @@ pub fn ChatView() -> impl IntoView {
 /// Automatically scrolls to the bottom whenever new messages arrive.
 #[component]
 pub fn MessageList(
-    messages: ReadSignal<Vec<ChatMessage>>,
-    /// When `true`, a "Thinking…" indicator is shown and the list scrolls to bottom.
-    #[prop(into)]
-    loading: Signal<bool>,
+    messages: impl Fn() -> Vec<ChatMessage> + Copy + Send + 'static,
+    #[prop(into)] loading: Signal<bool>,
 ) -> impl IntoView {
     let scroll_ref: NodeRef<leptos::html::Div> = NodeRef::new();
 
     // Scroll to bottom whenever the message list changes or loading toggles.
     Effect::new(move |_| {
-        let _ = messages.get();
+        let _ = messages();
         let _ = loading.get();
         if let Some(el) = scroll_ref.get() {
             let opts = web_sys::ScrollToOptions::new();
@@ -158,7 +305,7 @@ pub fn MessageList(
     view! {
         <div class="scroll-area message-list" node_ref=scroll_ref>
             <For
-                each=move || messages.get()
+                each=messages
                 key=|msg: &ChatMessage| msg.id
                 let(msg)
             >

--- a/frontend/src/components/mod.rs
+++ b/frontend/src/components/mod.rs
@@ -1,1 +1,3 @@
 pub mod chat;
+pub mod settings;
+pub mod sidebar;

--- a/frontend/src/components/settings.rs
+++ b/frontend/src/components/settings.rs
@@ -1,0 +1,125 @@
+//! Settings modal component for configuring API endpoint and auth key.
+
+use crate::state::AppState;
+use leptos::prelude::*;
+
+/// Modal overlay for application settings.
+///
+/// Allows the user to configure the API endpoint URL and an optional
+/// authentication key. Changes are saved to the global `AppState` on submit.
+#[component]
+pub fn SettingsModal() -> impl IntoView {
+    let state = AppState::expect();
+
+    // Local form state (staged until save).
+    let (endpoint, set_endpoint) = signal(String::new());
+    let (auth_key, set_auth_key) = signal(String::new());
+    let (show_key, set_show_key) = signal(false);
+
+    // Sync local form state from global settings when modal opens.
+    Effect::new(move |_| {
+        if state.settings_open.get() {
+            let s = state.settings.get();
+            set_endpoint.set(s.api_endpoint.clone());
+            set_auth_key.set(s.auth_key.clone());
+        }
+    });
+
+    let close = move || {
+        state.settings_open.set(false);
+    };
+
+    let on_save = move |_| {
+        state.settings.update(|s| {
+            s.api_endpoint = endpoint.get();
+            s.auth_key = auth_key.get();
+        });
+        close();
+    };
+
+    let on_backdrop_click = move |ev: web_sys::MouseEvent| {
+        if ev.target() == ev.current_target() {
+            close();
+        }
+    };
+
+    let on_escape = move |ev: web_sys::KeyboardEvent| {
+        if ev.key() == "Escape" {
+            close();
+        }
+    };
+
+    view! {
+        <Show when=move || state.settings_open.get()>
+            <div
+                class="modal-backdrop"
+                on:click=on_backdrop_click
+                on:keydown=on_escape
+                tabindex="-1"
+                role="dialog"
+                aria-modal="true"
+                aria-label="Settings"
+            >
+                <div class="modal-content" on:keydown=on_escape>
+                    <div class="modal-header">
+                        <h2 class="modal-title">"Settings"</h2>
+                        <button class="modal-close" on:click=move |_| close() aria-label="Close settings">
+                            "×"
+                        </button>
+                    </div>
+
+                    <div class="modal-body">
+                        <div class="form-group">
+                            <label class="form-label" for="api-endpoint">
+                                "API Endpoint"
+                            </label>
+                            <input
+                                id="api-endpoint"
+                                class="form-input"
+                                type="url"
+                                placeholder="http://localhost:11434"
+                                prop:value=move || endpoint.get()
+                                on:input:target=move |ev| set_endpoint.set(ev.target().value())
+                            />
+                            <span class="form-hint">"Leave empty to use the current origin."</span>
+                        </div>
+
+                        <div class="form-group">
+                            <label class="form-label" for="auth-key">
+                                "Auth Key"
+                                <span class="form-optional">"(optional)"</span>
+                            </label>
+                            <div class="input-row">
+                                <input
+                                    id="auth-key"
+                                    class="form-input"
+                                    type=move || if show_key.get() { "text" } else { "password" }
+                                    placeholder="sk-..."
+                                    prop:value=move || auth_key.get()
+                                    on:input:target=move |ev| set_auth_key.set(ev.target().value())
+                                />
+                                <button
+                                    class="toggle-visibility-btn"
+                                    on:click=move |_| set_show_key.update(|v| *v = !*v)
+                                    aria-label=move || if show_key.get() { "Hide key" } else { "Show key" }
+                                >
+                                    {move || if show_key.get() { "🙈" } else { "👁" }}
+                                </button>
+                            </div>
+                            <span class="form-hint">"Required for OpenAI, Anthropic, and other cloud providers."</span>
+                        </div>
+                    </div>
+
+                    <div class="modal-footer">
+                        <button class="btn-secondary" on:click=move |_| close()>
+                            "Cancel"
+                        </button>
+                        <button class="btn-primary" on:click=on_save>
+                            "Save"
+                        </button>
+                    </div>
+                </div>
+            </div>
+        </Show>
+    }
+}

--- a/frontend/src/components/sidebar.rs
+++ b/frontend/src/components/sidebar.rs
@@ -1,0 +1,98 @@
+//! Collapsible sidebar component showing chat threads and a settings button.
+
+use crate::state::AppState;
+use leptos::prelude::*;
+
+/// Collapsible sidebar panel with thread list and settings trigger.
+#[component]
+pub fn Sidebar() -> impl IntoView {
+    let state = AppState::expect();
+
+    let toggle_sidebar = move |_| {
+        state.sidebar_collapsed.update(|c| *c = !*c);
+    };
+
+    let new_chat = move |_| {
+        state.create_thread();
+    };
+
+    let open_settings = move |_| {
+        state.settings_open.set(true);
+    };
+
+    view! {
+        <nav
+            class="sidebar"
+            class:sidebar-collapsed=move || state.sidebar_collapsed.get()
+            aria-label="Chat navigation"
+        >
+            <div class="sidebar-header">
+                <button
+                    class="sidebar-toggle"
+                    on:click=toggle_sidebar
+                    aria-label=move || if state.sidebar_collapsed.get() { "Expand sidebar" } else { "Collapse sidebar" }
+                >
+                    {move || if state.sidebar_collapsed.get() { "☰" } else { "✕" }}
+                </button>
+                <Show when=move || !state.sidebar_collapsed.get()>
+                    <span class="sidebar-title">"Chats"</span>
+                </Show>
+            </div>
+
+            <Show when=move || !state.sidebar_collapsed.get()>
+                <button class="new-chat-btn" on:click=new_chat>
+                    "+ New Chat"
+                </button>
+
+                <div class="thread-list" role="list">
+                    <For
+                        each=move || state.threads.get()
+                        key=|thread| thread.id
+                        let(thread)
+                    >
+                        <div
+                            class="thread-item"
+                            class:thread-active=move || state.active_thread_id.get() == Some(thread.id)
+                            role="listitem"
+                            tabindex="0"
+                            on:click=move |_| {
+                                state.active_thread_id.set(Some(thread.id));
+                            }
+                            on:keydown=move |ev: web_sys::KeyboardEvent| {
+                                if ev.key() == "Enter" {
+                                    state.active_thread_id.set(Some(thread.id));
+                                }
+                            }
+                        >
+                            {
+                                let title = thread.title.clone();
+                                let title_aria = thread.title.clone();
+                                view! {
+                                    <span class="thread-title">{move || title.clone()}</span>
+                                    <button
+                                        class="thread-delete"
+                                        aria-label=move || format!("Delete {}", title_aria)
+                                        on:click=move |ev| {
+                                            ev.stop_propagation();
+                                            state.delete_thread(thread.id);
+                                        }
+                                    >
+                                        "×"
+                                    </button>
+                                }
+                            }
+                        </div>
+                    </For>
+                </div>
+            </Show>
+
+            <div class="sidebar-footer">
+                <button class="settings-btn" on:click=open_settings aria-label="Open settings">
+                    <Show when=move || !state.sidebar_collapsed.get() fallback=|| view! { "⚙" }>
+                        "⚙ Settings"
+                    </Show>
+                </button>
+            </div>
+        </nav>
+    }
+}

--- a/frontend/src/components/sidebar.rs
+++ b/frontend/src/components/sidebar.rs
@@ -73,8 +73,14 @@ pub fn Sidebar() -> impl IntoView {
                                         class="thread-delete"
                                         aria-label=move || format!("Delete {}", title_aria)
                                         on:click=move |ev| {
-                                            ev.stop_propagation();
-                                            state.delete_thread(thread.id);
+                                           ev.stop_propagation();
+                                           state.delete_thread(thread.id);
+                                       }
+                                        on:keydown=move |ev: web_sys::KeyboardEvent| {
+                                            if ev.key() == "Enter" {
+                                                ev.stop_propagation();
+                                                state.delete_thread(thread.id);
+                                            }
                                         }
                                     >
                                         "×"

--- a/frontend/src/components/sidebar.rs
+++ b/frontend/src/components/sidebar.rs
@@ -53,7 +53,8 @@ pub fn Sidebar() -> impl IntoView {
                         <div
                             class="thread-item"
                             class:thread-active=move || state.active_thread_id.get() == Some(thread.id)
-                            role="listitem"
+                            role="button"
+                            aria-selected=move || state.active_thread_id.get() == Some(thread.id)
                             tabindex="0"
                             on:click=move |_| {
                                 state.active_thread_id.set(Some(thread.id));

--- a/frontend/src/components/sidebar.rs
+++ b/frontend/src/components/sidebar.rs
@@ -59,7 +59,8 @@ pub fn Sidebar() -> impl IntoView {
                                 state.active_thread_id.set(Some(thread.id));
                             }
                             on:keydown=move |ev: web_sys::KeyboardEvent| {
-                                if ev.key() == "Enter" {
+                                if ev.key() == "Enter" || ev.key() == " " {
+                                    ev.prevent_default();
                                     state.active_thread_id.set(Some(thread.id));
                                 }
                             }
@@ -77,8 +78,9 @@ pub fn Sidebar() -> impl IntoView {
                                            state.delete_thread(thread.id);
                                        }
                                         on:keydown=move |ev: web_sys::KeyboardEvent| {
-                                            if ev.key() == "Enter" {
+                                            if ev.key() == "Enter" || ev.key() == " " {
                                                 ev.stop_propagation();
+                                                ev.prevent_default();
                                                 state.delete_thread(thread.id);
                                             }
                                         }

--- a/frontend/src/lib.rs
+++ b/frontend/src/lib.rs
@@ -1,15 +1,25 @@
 mod api;
 mod components;
+mod state;
 
 use components::chat::ChatView;
+use components::settings::SettingsModal;
+use components::sidebar::Sidebar;
 use leptos::prelude::*;
+use state::AppState;
 use wasm_bindgen::prelude::*;
 
 #[component]
 pub fn App() -> impl IntoView {
+    AppState::provide();
+
     view! {
-        <div class="app-root">
-            <ChatView />
+        <div class="app-layout">
+            <Sidebar />
+            <main class="chat-main">
+                <ChatView />
+            </main>
+            <SettingsModal />
         </div>
     }
 }

--- a/frontend/src/state.rs
+++ b/frontend/src/state.rs
@@ -50,6 +50,8 @@ pub struct AppState {
     pub models_loading: RwSignal<bool>,
     /// Error message from model fetch, if any.
     pub models_error: RwSignal<Option<String>>,
+    /// Monotonic token to discard stale model-fetch responses.
+    pub models_request_id: RwSignal<u64>,
 }
 
 impl AppState {
@@ -66,6 +68,7 @@ impl AppState {
             available_models: RwSignal::new(Vec::new()),
             models_loading: RwSignal::new(false),
             models_error: RwSignal::new(None),
+            models_request_id: RwSignal::new(0),
         };
         provide_context(state);
         state
@@ -107,24 +110,26 @@ impl AppState {
     /// Returns None if no thread is active.
     #[allow(dead_code)]
     pub fn active_thread(&self) -> Option<ChatThread> {
-        let threads = self.threads.get();
         let active_id = self.active_thread_id.get()?;
-        threads.into_iter().find(|t| t.id == active_id)
+        self.threads.with(|threads| {
+            threads.iter().find(|t| t.id == active_id).cloned()
+        })
     }
 
     /// Get the active thread's messages directly, avoiding cloning the full ChatThread.
     /// Returns an empty Vec if no thread is active.
     pub fn active_messages(&self) -> Vec<super::components::chat::ChatMessage> {
-        let threads = self.threads.get();
         let active_id = match self.active_thread_id.get() {
             Some(id) => id,
             None => return Vec::new(),
         };
-        threads
-            .iter()
-            .find(|t| t.id == active_id)
-            .map(|t| t.messages.clone())
-            .unwrap_or_default()
+        self.threads.with(|threads| {
+            threads
+                .iter()
+                .find(|t| t.id == active_id)
+                .map(|t| t.messages.clone())
+                .unwrap_or_default()
+        })
     }
 
     /// Fetch the list of available models from the configured provider.
@@ -133,17 +138,23 @@ impl AppState {
         let auth_key = self.settings.get().auth_key.clone();
         self.models_loading.set(true);
         self.models_error.set(None);
+        let request_id = self.models_request_id.get() + 1;
+        self.models_request_id.set(request_id);
 
+        let state = *self;
         leptos::task::spawn_local(async move {
-            let state = Self::expect();
             match api::fetch_models(&endpoint, &auth_key).await {
                 Ok(models) => {
-                    state.available_models.set(models);
-                    state.models_loading.set(false);
+                    if state.models_request_id.get() == request_id {
+                        state.available_models.set(models);
+                        state.models_loading.set(false);
+                    }
                 }
                 Err(error) => {
-                    state.models_error.set(Some(error.to_string()));
-                    state.models_loading.set(false);
+                    if state.models_request_id.get() == request_id {
+                        state.models_error.set(Some(error.to_string()));
+                        state.models_loading.set(false);
+                    }
                 }
             }
         });

--- a/frontend/src/state.rs
+++ b/frontend/src/state.rs
@@ -153,6 +153,7 @@ impl AppState {
                 Err(error) => {
                     if state.models_request_id.get() == request_id {
                         state.models_error.set(Some(error.to_string()));
+                        state.available_models.set(Vec::new());
                         state.models_loading.set(false);
                     }
                 }

--- a/frontend/src/state.rs
+++ b/frontend/src/state.rs
@@ -60,7 +60,7 @@ impl AppState {
             active_thread_id: RwSignal::new(None),
             next_thread_id: RwSignal::new(0),
             settings: RwSignal::new(AppSettings::default()),
-            selected_model: RwSignal::new("llama3".to_string()),
+            selected_model: RwSignal::new(api::DEFAULT_MODEL.to_string()),
             sidebar_collapsed: RwSignal::new(false),
             settings_open: RwSignal::new(false),
             available_models: RwSignal::new(Vec::new()),
@@ -94,21 +94,37 @@ impl AppState {
     /// Delete a thread by ID. If the deleted thread was active, switch to
     /// the most recent remaining thread (or None if empty).
     pub fn delete_thread(&self, thread_id: ThreadId) {
-        self.threads
-            .update(|threads| threads.retain(|t| t.id != thread_id));
-        let current = self.active_thread_id.get();
-        if current == Some(thread_id) {
-            let threads = self.threads.get();
-            self.active_thread_id.set(threads.last().map(|t| t.id));
-        }
+        self.threads.update(|threads| {
+            threads.retain(|t| t.id != thread_id);
+            let current = self.active_thread_id.get();
+            if current == Some(thread_id) {
+                self.active_thread_id.set(threads.last().map(|t| t.id));
+            }
+        });
     }
 
-    /// Get the active thread's messages as a signal-friendly structure.
+    /// Get the active thread by value (clones the entire thread including messages).
     /// Returns None if no thread is active.
+    #[allow(dead_code)]
     pub fn active_thread(&self) -> Option<ChatThread> {
         let threads = self.threads.get();
         let active_id = self.active_thread_id.get()?;
         threads.into_iter().find(|t| t.id == active_id)
+    }
+
+    /// Get the active thread's messages directly, avoiding cloning the full ChatThread.
+    /// Returns an empty Vec if no thread is active.
+    pub fn active_messages(&self) -> Vec<super::components::chat::ChatMessage> {
+        let threads = self.threads.get();
+        let active_id = match self.active_thread_id.get() {
+            Some(id) => id,
+            None => return Vec::new(),
+        };
+        threads
+            .iter()
+            .find(|t| t.id == active_id)
+            .map(|t| t.messages.clone())
+            .unwrap_or_default()
     }
 
     /// Fetch the list of available models from the configured provider.

--- a/frontend/src/state.rs
+++ b/frontend/src/state.rs
@@ -1,0 +1,135 @@
+//! Global application state for the LibreChat frontend.
+//!
+//! Provides reactive signals for chat threads, settings, and model selection.
+//! All state lives in-memory via Leptos context — no persistence layer yet.
+
+use crate::api::{self, ApiModelInfo};
+use leptos::prelude::*;
+
+/// Unique identifier for a chat thread.
+pub type ThreadId = usize;
+
+/// A single chat thread containing its message history and metadata.
+#[derive(Debug, Clone)]
+pub struct ChatThread {
+    pub id: ThreadId,
+    pub title: String,
+    pub messages: Vec<super::components::chat::ChatMessage>,
+}
+
+/// Application-wide settings (in-memory, not persisted).
+#[derive(Debug, Clone, Default)]
+pub struct AppSettings {
+    /// API endpoint URL (e.g. "http://localhost:11434" for Ollama).
+    pub api_endpoint: String,
+    /// Optional authentication key for the API.
+    pub auth_key: String,
+}
+
+/// Provides the global application state via Leptos context.
+/// Call once at the app root.
+#[derive(Debug, Clone, Copy)]
+pub struct AppState {
+    /// All chat threads.
+    pub threads: RwSignal<Vec<ChatThread>>,
+    /// ID of the currently active thread.
+    pub active_thread_id: RwSignal<Option<ThreadId>>,
+    /// Counter for generating unique thread IDs.
+    pub next_thread_id: RwSignal<ThreadId>,
+    /// Application settings (API endpoint, auth key).
+    pub settings: RwSignal<AppSettings>,
+    /// Currently selected model name.
+    pub selected_model: RwSignal<String>,
+    /// Whether the sidebar is collapsed.
+    pub sidebar_collapsed: RwSignal<bool>,
+    /// Whether the settings modal is open.
+    pub settings_open: RwSignal<bool>,
+    /// Available models fetched from the provider.
+    pub available_models: RwSignal<Vec<ApiModelInfo>>,
+    /// Whether models are currently being fetched.
+    pub models_loading: RwSignal<bool>,
+    /// Error message from model fetch, if any.
+    pub models_error: RwSignal<Option<String>>,
+}
+
+impl AppState {
+    /// Initialize and provide the app state via Leptos context.
+    pub fn provide() -> Self {
+        let state = Self {
+            threads: RwSignal::new(Vec::new()),
+            active_thread_id: RwSignal::new(None),
+            next_thread_id: RwSignal::new(0),
+            settings: RwSignal::new(AppSettings::default()),
+            selected_model: RwSignal::new("llama3".to_string()),
+            sidebar_collapsed: RwSignal::new(false),
+            settings_open: RwSignal::new(false),
+            available_models: RwSignal::new(Vec::new()),
+            models_loading: RwSignal::new(false),
+            models_error: RwSignal::new(None),
+        };
+        provide_context(state);
+        state
+    }
+
+    /// Retrieve the app state from Leptos context. Panics if not provided.
+    pub fn expect() -> Self {
+        expect_context()
+    }
+
+    /// Create a new thread, add it to the threads list, and set it as active.
+    pub fn create_thread(&self) {
+        let id = self.next_thread_id.get();
+        self.next_thread_id.update(|n| *n += 1);
+
+        let thread = ChatThread {
+            id,
+            title: format!("Chat {}", id + 1),
+            messages: Vec::new(),
+        };
+
+        self.threads.update(|threads| threads.push(thread));
+        self.active_thread_id.set(Some(id));
+    }
+
+    /// Delete a thread by ID. If the deleted thread was active, switch to
+    /// the most recent remaining thread (or None if empty).
+    pub fn delete_thread(&self, thread_id: ThreadId) {
+        self.threads
+            .update(|threads| threads.retain(|t| t.id != thread_id));
+        let current = self.active_thread_id.get();
+        if current == Some(thread_id) {
+            let threads = self.threads.get();
+            self.active_thread_id.set(threads.last().map(|t| t.id));
+        }
+    }
+
+    /// Get the active thread's messages as a signal-friendly structure.
+    /// Returns None if no thread is active.
+    pub fn active_thread(&self) -> Option<ChatThread> {
+        let threads = self.threads.get();
+        let active_id = self.active_thread_id.get()?;
+        threads.into_iter().find(|t| t.id == active_id)
+    }
+
+    /// Fetch the list of available models from the configured provider.
+    pub fn refresh_models(&self) {
+        let endpoint = self.settings.get().api_endpoint.clone();
+        let auth_key = self.settings.get().auth_key.clone();
+        self.models_loading.set(true);
+        self.models_error.set(None);
+
+        leptos::task::spawn_local(async move {
+            let state = Self::expect();
+            match api::fetch_models(&endpoint, &auth_key).await {
+                Ok(models) => {
+                    state.available_models.set(models);
+                    state.models_loading.set(false);
+                }
+                Err(error) => {
+                    state.models_error.set(Some(error.to_string()));
+                    state.models_loading.set(false);
+                }
+            }
+        });
+    }
+}

--- a/frontend/style/main.css
+++ b/frontend/style/main.css
@@ -351,6 +351,15 @@ textarea:focus-visible {
   opacity: 1;
 }
 
+.thread-delete:focus,
+.thread-delete:focus-visible {
+  opacity: 1;
+}
+
+.thread-item:focus-within .thread-delete {
+  opacity: 1;
+}
+
 .thread-delete:hover {
   color: var(--color-error);
 }
@@ -852,3 +861,4 @@ textarea:focus-visible {
     --sidebar-width: 260px;
   }
 }
+  --font-sans: system-ui, -apple-system, "segoe ui", roboto, helvetica, arial, sans-serif;

--- a/frontend/style/main.css
+++ b/frontend/style/main.css
@@ -364,6 +364,13 @@ textarea:focus-visible {
   color: var(--color-error);
 }
 
+/* Show delete button on touch devices */
+@media (pointer: coarse) {
+  .thread-delete {
+    opacity: 1;
+  }
+}
+
 /* Sidebar footer */
 .sidebar-footer {
   flex-shrink: 0;
@@ -861,4 +868,4 @@ textarea:focus-visible {
     --sidebar-width: 260px;
   }
 }
-  --font-sans: system-ui, -apple-system, "segoe ui", roboto, helvetica, arial, sans-serif;
+

--- a/frontend/style/main.css
+++ b/frontend/style/main.css
@@ -1,44 +1,78 @@
 /* ==========================================================================
    LibreChat Design System — Global Stylesheet
+   Premium luxury aesthetic · System font · Dark theme
    ========================================================================== */
 
 /* --------------------------------------------------------------------------
    1. Design Tokens (CSS Custom Properties)
    -------------------------------------------------------------------------- */
 :root {
-  /* Colour palette — dark theme */
-  --color-bg-primary: #111827;
-  --color-bg-secondary: #1f2937;
-  --color-bg-input: #374151;
-  --color-text-primary: #f9fafb;
-  --color-text-secondary: #9ca3af;
-  --color-accent: #3b82f6;
-  --color-accent-hover: #2563eb;
-  --color-border: #4b5563;
+  /* Colour palette — premium dark theme */
+  --color-bg-primary: #0a0a0b;
+  --color-bg-secondary: #141416;
+  --color-bg-tertiary: #1a1a1e;
+  --color-bg-input: #1e1e23;
+  --color-bg-hover: #242429;
+  --color-text-primary: #ececec;
+  --color-text-secondary: #7a7a85;
+  --color-text-tertiary: #4a4a55;
+  --color-accent: #a78bfa;
+  --color-accent-hover: #8b6ff0;
+  --color-accent-muted: rgba(167, 139, 250, 0.12);
+  --color-border: #222228;
+  --color-border-subtle: #1a1a1f;
+  --color-error: #ef4444;
+  --color-error-bg: rgba(127, 29, 29, 0.4);
 
-  /* Typography */
-  --font-sans: system-ui, -apple-system, sans-serif;
-  --font-mono: ui-monospace, "Cascadia Code", "Fira Code", monospace;
+  /* Typography — system font stack */
+  --font-sans: system-ui, -apple-system, "Segoe UI", Roboto, Helvetica, Arial, sans-serif;
+  --font-mono: ui-monospace, "Cascadia Code", "Fira Code", "JetBrains Mono", monospace;
+
+  /* Type scale */
+  --text-xs: 0.75rem;
+  --text-sm: 0.8125rem;
+  --text-base: 0.875rem;
+  --text-md: 1rem;
+  --text-lg: 1.125rem;
+  --text-xl: 1.5rem;
+  --text-2xl: 2rem;
+
+  /* Font weights */
+  --weight-normal: 400;
+  --weight-medium: 500;
+  --weight-semibold: 600;
 
   /* Spacing scale */
+  --space-2xs: 0.125rem;
   --space-xs: 0.25rem;
   --space-sm: 0.5rem;
-  --space-md: 1rem;
-  --space-lg: 1.5rem;
-  --space-xl: 2rem;
+  --space-md: 0.75rem;
+  --space-lg: 1rem;
+  --space-xl: 1.5rem;
+  --space-2xl: 2rem;
+  --space-3xl: 3rem;
 
   /* Border radii */
-  --radius-sm: 0.25rem;
+  --radius-xs: 0.1875rem;
+  --radius-sm: 0.375rem;
   --radius-md: 0.5rem;
   --radius-lg: 0.75rem;
+  --radius-xl: 1rem;
 
   /* Shadows */
   --shadow-sm: 0 1px 2px rgba(0, 0, 0, 0.3);
-  --shadow-md: 0 4px 6px rgba(0, 0, 0, 0.4);
+  --shadow-md: 0 4px 8px rgba(0, 0, 0, 0.4);
+  --shadow-lg: 0 8px 24px rgba(0, 0, 0, 0.5);
+  --shadow-inset: inset 0 1px 2px rgba(0, 0, 0, 0.2);
 
   /* Transitions */
-  --transition-fast: 150ms ease;
-  --transition-normal: 250ms ease;
+  --transition-fast: 120ms ease;
+  --transition-normal: 200ms ease;
+  --transition-slow: 300ms ease;
+
+  /* Layout */
+  --sidebar-width: 280px;
+  --sidebar-collapsed-width: 52px;
 }
 
 /* --------------------------------------------------------------------------
@@ -56,8 +90,8 @@ html,
 body {
   height: 100%;
   font-family: var(--font-sans);
-  font-size: 16px;
-  line-height: 1.5;
+  font-size: var(--text-base);
+  line-height: 1.6;
   color: var(--color-text-primary);
   background-color: var(--color-bg-primary);
   -webkit-font-smoothing: antialiased;
@@ -66,24 +100,45 @@ body {
 
 a {
   color: var(--color-accent);
-  text-decoration: underline;
+  text-decoration: none;
 }
 
 a:hover {
   color: var(--color-accent-hover);
 }
 
-a:focus-visible {
+a:focus-visible,
+button:focus-visible,
+input:focus-visible,
+select:focus-visible,
+textarea:focus-visible {
   outline: 2px solid var(--color-accent);
-  outline-offset: 2px;
+  outline-offset: 1px;
 }
 
 /* --------------------------------------------------------------------------
    3. Layout Utilities
    -------------------------------------------------------------------------- */
 
-/* Full-height flex column — used for the app root and chat shell */
+/* Full-height flex column — used for the chat shell */
 .flex-column-full {
+  display: flex;
+  flex-direction: column;
+  height: 100%;
+}
+
+/* App layout — horizontal split: sidebar + main */
+.app-layout {
+  display: flex;
+  height: 100%;
+  background-color: var(--color-bg-primary);
+  color: var(--color-text-primary);
+}
+
+/* Chat main content area */
+.chat-main {
+  flex: 1 1 0;
+  min-width: 0;
   display: flex;
   flex-direction: column;
   height: 100%;
@@ -94,19 +149,19 @@ a:focus-visible {
   flex: 1 1 0;
   min-height: 0;
   overflow-y: auto;
-  padding: var(--space-md);
+  padding: var(--space-xl) var(--space-2xl);
 }
 
 /* Sticky input bar pinned to the bottom */
 .sticky-input {
   flex-shrink: 0;
-  padding: var(--space-sm) var(--space-md);
-  border-top: 1px solid var(--color-border);
-  background-color: var(--color-bg-secondary);
+  padding: var(--space-md) var(--space-xl);
+  border-top: 1px solid var(--color-border-subtle);
+  background-color: var(--color-bg-primary);
 }
 
 /* --------------------------------------------------------------------------
-   4. App Root
+   4. App Root (retained for backward compat with tests)
    -------------------------------------------------------------------------- */
 .app-root {
   display: flex;
@@ -119,17 +174,20 @@ a:focus-visible {
 /* --------------------------------------------------------------------------
    5. Scrollbar Styling (Webkit)
    -------------------------------------------------------------------------- */
-.scroll-area::-webkit-scrollbar {
-  width: 6px;
+.scroll-area::-webkit-scrollbar,
+.thread-list::-webkit-scrollbar {
+  width: 4px;
 }
 
-.scroll-area::-webkit-scrollbar-track {
+.scroll-area::-webkit-scrollbar-track,
+.thread-list::-webkit-scrollbar-track {
   background: transparent;
 }
 
-.scroll-area::-webkit-scrollbar-thumb {
+.scroll-area::-webkit-scrollbar-thumb,
+.thread-list::-webkit-scrollbar-thumb {
   background-color: var(--color-border);
-  border-radius: 3px;
+  border-radius: 2px;
 }
 
 /* --------------------------------------------------------------------------
@@ -146,40 +204,331 @@ a:focus-visible {
   white-space: nowrap;
   border: 0;
 }
-/* --------------------------------------------------------------------------
-   7. Chat UI Components
-   -------------------------------------------------------------------------- */
 
-/* Message list container — uses the scroll-area layout utility */
+/* ==========================================================================
+   7. Sidebar
+   ========================================================================== */
+.sidebar {
+  display: flex;
+  flex-direction: column;
+  width: var(--sidebar-width);
+  min-width: var(--sidebar-width);
+  height: 100%;
+  background-color: var(--color-bg-secondary);
+  border-right: 1px solid var(--color-border-subtle);
+  transition: width var(--transition-normal), min-width var(--transition-normal);
+  overflow: hidden;
+}
+
+.sidebar.sidebar-collapsed {
+  width: var(--sidebar-collapsed-width);
+  min-width: var(--sidebar-collapsed-width);
+}
+
+.sidebar-header {
+  display: flex;
+  align-items: center;
+  gap: var(--space-sm);
+  padding: var(--space-md);
+  border-bottom: 1px solid var(--color-border-subtle);
+  min-height: 52px;
+}
+
+.sidebar-toggle {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 28px;
+  height: 28px;
+  font-size: var(--text-md);
+  color: var(--color-text-secondary);
+  background: none;
+  border: none;
+  border-radius: var(--radius-sm);
+  cursor: pointer;
+  transition: color var(--transition-fast), background-color var(--transition-fast);
+  flex-shrink: 0;
+}
+
+.sidebar-toggle:hover {
+  color: var(--color-text-primary);
+  background-color: var(--color-bg-hover);
+}
+
+.sidebar-title {
+  font-size: var(--text-sm);
+  font-weight: var(--weight-semibold);
+  letter-spacing: 0.05em;
+  text-transform: uppercase;
+  color: var(--color-text-secondary);
+  white-space: nowrap;
+}
+
+/* New chat button */
+.new-chat-btn {
+  display: flex;
+  align-items: center;
+  gap: var(--space-sm);
+  width: calc(100% - var(--space-xl));
+  margin: var(--space-md) auto 0;
+  padding: var(--space-sm) var(--space-md);
+  font-family: var(--font-sans);
+  font-size: var(--text-sm);
+  font-weight: var(--weight-medium);
+  color: var(--color-accent);
+  background-color: var(--color-accent-muted);
+  border: 1px solid rgba(167, 139, 250, 0.2);
+  border-radius: var(--radius-md);
+  cursor: pointer;
+  transition: background-color var(--transition-fast), border-color var(--transition-fast);
+}
+
+.new-chat-btn:hover {
+  background-color: rgba(167, 139, 250, 0.18);
+  border-color: rgba(167, 139, 250, 0.35);
+}
+
+/* Thread list */
+.thread-list {
+  flex: 1 1 0;
+  min-height: 0;
+  overflow-y: auto;
+  padding: var(--space-sm) var(--space-md);
+}
+
+/* Individual thread item */
+.thread-item {
+  display: flex;
+  align-items: center;
+  gap: var(--space-sm);
+  padding: var(--space-sm) var(--space-md);
+  border-radius: var(--radius-sm);
+  cursor: pointer;
+  transition: background-color var(--transition-fast);
+  position: relative;
+}
+
+.thread-item:hover {
+  background-color: var(--color-bg-hover);
+}
+
+.thread-item.thread-active {
+  background-color: var(--color-bg-tertiary);
+}
+
+.thread-title {
+  flex: 1 1 0;
+  font-size: var(--text-sm);
+  color: var(--color-text-primary);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  min-width: 0;
+}
+
+.thread-item.thread-active .thread-title {
+  color: var(--color-text-primary);
+}
+
+.thread-delete {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 20px;
+  height: 20px;
+  font-size: var(--text-sm);
+  color: var(--color-text-tertiary);
+  background: none;
+  border: none;
+  border-radius: var(--radius-xs);
+  cursor: pointer;
+  opacity: 0;
+  transition: opacity var(--transition-fast), color var(--transition-fast);
+  flex-shrink: 0;
+}
+
+.thread-item:hover .thread-delete {
+  opacity: 1;
+}
+
+.thread-delete:hover {
+  color: var(--color-error);
+}
+
+/* Sidebar footer */
+.sidebar-footer {
+  flex-shrink: 0;
+  padding: var(--space-md);
+  border-top: 1px solid var(--color-border-subtle);
+}
+
+.settings-btn {
+  display: flex;
+  align-items: center;
+  gap: var(--space-sm);
+  width: 100%;
+  padding: var(--space-sm) var(--space-md);
+  font-family: var(--font-sans);
+  font-size: var(--text-sm);
+  color: var(--color-text-secondary);
+  background: none;
+  border: 1px solid transparent;
+  border-radius: var(--radius-sm);
+  cursor: pointer;
+  transition: color var(--transition-fast), background-color var(--transition-fast);
+}
+
+.settings-btn:hover {
+  color: var(--color-text-primary);
+  background-color: var(--color-bg-hover);
+}
+
+/* ==========================================================================
+   8. Chat Header & Model Selector
+   ========================================================================== */
+.chat-header {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: var(--space-md) var(--space-xl);
+  border-bottom: 1px solid var(--color-border-subtle);
+  background-color: var(--color-bg-primary);
+  flex-shrink: 0;
+}
+
+.model-selector {
+  display: flex;
+  align-items: center;
+  gap: var(--space-sm);
+}
+
+.model-select {
+  appearance: none;
+  padding: var(--space-xs) var(--space-lg) var(--space-xs) var(--space-md);
+  font-family: var(--font-sans);
+  font-size: var(--text-sm);
+  font-weight: var(--weight-medium);
+  color: var(--color-text-primary);
+  background-color: var(--color-bg-tertiary);
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-md);
+  cursor: pointer;
+  transition: border-color var(--transition-fast);
+  background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='12' height='12' viewBox='0 0 12 12'%3E%3Cpath d='M3 5l3 3 3-3' fill='none' stroke='%237a7a85' stroke-width='1.5' stroke-linecap='round'/%3E%3C/svg%3E");
+  background-repeat: no-repeat;
+  background-position: right var(--space-sm) center;
+  padding-right: var(--space-xl);
+  min-width: 180px;
+}
+
+.model-select:hover {
+  border-color: var(--color-text-tertiary);
+}
+
+.model-select:focus {
+  border-color: var(--color-accent);
+}
+
+.model-custom-input {
+  display: flex;
+  align-items: center;
+  gap: var(--space-xs);
+}
+
+.model-input {
+  min-width: 180px;
+  padding: var(--space-xs) var(--space-md);
+}
+
+.model-back-btn {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 28px;
+  height: 28px;
+  font-size: var(--text-sm);
+  color: var(--color-text-secondary);
+  background: none;
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-sm);
+  cursor: pointer;
+  transition: color var(--transition-fast), border-color var(--transition-fast);
+}
+
+.model-back-btn:hover {
+  color: var(--color-text-primary);
+  border-color: var(--color-text-tertiary);
+}
+
+.model-error-hint {
+  font-size: var(--text-sm);
+  color: var(--color-text-tertiary);
+  cursor: help;
+}
+
+/* ==========================================================================
+   9. Chat Welcome Screen
+   ========================================================================== */
+.chat-welcome {
+  flex: 1 1 0;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: var(--space-md);
+  padding: var(--space-3xl);
+}
+
+.welcome-title {
+  font-size: var(--text-2xl);
+  font-weight: var(--weight-semibold);
+  color: var(--color-text-primary);
+  letter-spacing: -0.02em;
+}
+
+.welcome-subtitle {
+  font-size: var(--text-base);
+  color: var(--color-text-secondary);
+  text-align: center;
+  max-width: 320px;
+}
+
+/* ==========================================================================
+   10. Chat UI — Messages
+   ========================================================================== */
+
+/* Message list container */
 .message-list {
   display: flex;
   flex-direction: column;
-  gap: var(--space-sm);
+  gap: var(--space-lg);
 }
 
 /* Base bubble style shared by all messages */
 .message-bubble {
-  max-width: 75%;
-  padding: var(--space-sm) var(--space-md);
+  max-width: 72%;
+  padding: var(--space-md) var(--space-lg);
   border-radius: var(--radius-lg);
   overflow-wrap: break-word;
-  line-height: 1.5;
+  line-height: 1.6;
+  font-size: var(--text-base);
 }
 
 /* User messages — right-aligned with accent background */
 .message-user {
   align-self: flex-end;
-  background-color: var(--color-accent);
-  color: #ffffff;
-  border-bottom-right-radius: var(--radius-sm);
+  background-color: var(--color-accent-muted);
+  color: var(--color-text-primary);
+  border: 1px solid rgba(167, 139, 250, 0.15);
+  border-bottom-right-radius: var(--radius-xs);
 }
 
-/* Assistant messages — left-aligned with secondary background */
+/* Assistant messages — left-aligned with subtle background */
 .message-assistant {
   align-self: flex-start;
-  background-color: var(--color-bg-secondary);
+  background-color: var(--color-bg-tertiary);
   color: var(--color-text-primary);
-  border-bottom-left-radius: var(--radius-sm);
+  border-bottom-left-radius: var(--radius-xs);
 }
 
 /* Chat input area — textarea + send button row */
@@ -197,8 +546,8 @@ a:focus-visible {
   resize: vertical;
   padding: var(--space-sm) var(--space-md);
   font-family: var(--font-sans);
-  font-size: 1rem;
-  line-height: 1.5;
+  font-size: var(--text-base);
+  line-height: 1.6;
   color: var(--color-text-primary);
   background-color: var(--color-bg-input);
   border: 1px solid var(--color-border);
@@ -212,7 +561,7 @@ a:focus-visible {
 }
 
 .chat-textarea::placeholder {
-  color: var(--color-text-secondary);
+  color: var(--color-text-tertiary);
 }
 
 /* Send button */
@@ -220,8 +569,8 @@ a:focus-visible {
   flex-shrink: 0;
   padding: var(--space-sm) var(--space-lg);
   font-family: var(--font-sans);
-  font-size: 1rem;
-  font-weight: 600;
+  font-size: var(--text-sm);
+  font-weight: var(--weight-semibold);
   color: #ffffff;
   background-color: var(--color-accent);
   border: none;
@@ -237,35 +586,201 @@ a:focus-visible {
 }
 
 .send-btn:disabled {
-  opacity: 0.5;
+  opacity: 0.4;
   cursor: not-allowed;
 }
 
-/* --------------------------------------------------------------------------
-   8. Responsive — Chat UI
-   -------------------------------------------------------------------------- */
-@media (max-width: 640px) {
-  .message-bubble {
-    max-width: 90%;
-  }
-
-  .chat-input-area {
-    flex-direction: column;
-  }
-
-  .send-btn {
-    width: 100%;
-  }
+/* ==========================================================================
+   11. Settings Modal
+   ========================================================================== */
+.modal-backdrop {
+  position: fixed;
+  inset: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background-color: rgba(0, 0, 0, 0.6);
+  z-index: 100;
 }
 
-/* --------------------------------------------------------------------------
-   9. Loading & Error States
-   -------------------------------------------------------------------------- */
+.modal-content {
+  width: 100%;
+  max-width: 440px;
+  background-color: var(--color-bg-secondary);
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-xl);
+  box-shadow: var(--shadow-lg);
+}
+
+.modal-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: var(--space-lg) var(--space-xl);
+  border-bottom: 1px solid var(--color-border-subtle);
+}
+
+.modal-title {
+  font-size: var(--text-md);
+  font-weight: var(--weight-semibold);
+  color: var(--color-text-primary);
+}
+
+.modal-close {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 28px;
+  height: 28px;
+  font-size: var(--text-lg);
+  color: var(--color-text-secondary);
+  background: none;
+  border: none;
+  border-radius: var(--radius-sm);
+  cursor: pointer;
+  transition: color var(--transition-fast), background-color var(--transition-fast);
+}
+
+.modal-close:hover {
+  color: var(--color-text-primary);
+  background-color: var(--color-bg-hover);
+}
+
+.modal-body {
+  padding: var(--space-xl);
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-lg);
+}
+
+.modal-footer {
+  display: flex;
+  align-items: center;
+  justify-content: flex-end;
+  gap: var(--space-sm);
+  padding: var(--space-lg) var(--space-xl);
+  border-top: 1px solid var(--color-border-subtle);
+}
+
+/* Form controls */
+.form-group {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-xs);
+}
+
+.form-label {
+  font-size: var(--text-sm);
+  font-weight: var(--weight-medium);
+  color: var(--color-text-secondary);
+}
+
+.form-optional {
+  font-weight: var(--weight-normal);
+  color: var(--color-text-tertiary);
+  margin-left: var(--space-xs);
+}
+
+.form-input {
+  padding: var(--space-sm) var(--space-md);
+  font-family: var(--font-sans);
+  font-size: var(--text-base);
+  color: var(--color-text-primary);
+  background-color: var(--color-bg-input);
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-md);
+  outline: none;
+  transition: border-color var(--transition-fast);
+}
+
+.form-input:focus {
+  border-color: var(--color-accent);
+}
+
+.form-input::placeholder {
+  color: var(--color-text-tertiary);
+}
+
+.form-hint {
+  font-size: var(--text-xs);
+  color: var(--color-text-tertiary);
+}
+
+.input-row {
+  display: flex;
+  gap: var(--space-xs);
+  align-items: center;
+}
+
+.input-row .form-input {
+  flex: 1 1 0;
+}
+
+.toggle-visibility-btn {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 36px;
+  height: 36px;
+  font-size: var(--text-base);
+  background: none;
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-md);
+  cursor: pointer;
+  color: var(--color-text-secondary);
+  transition: border-color var(--transition-fast), color var(--transition-fast);
+  flex-shrink: 0;
+}
+
+.toggle-visibility-btn:hover {
+  border-color: var(--color-text-tertiary);
+  color: var(--color-text-primary);
+}
+
+/* Modal buttons */
+.btn-primary {
+  padding: var(--space-sm) var(--space-lg);
+  font-family: var(--font-sans);
+  font-size: var(--text-sm);
+  font-weight: var(--weight-semibold);
+  color: #ffffff;
+  background-color: var(--color-accent);
+  border: none;
+  border-radius: var(--radius-md);
+  cursor: pointer;
+  transition: background-color var(--transition-fast);
+}
+
+.btn-primary:hover {
+  background-color: var(--color-accent-hover);
+}
+
+.btn-secondary {
+  padding: var(--space-sm) var(--space-lg);
+  font-family: var(--font-sans);
+  font-size: var(--text-sm);
+  font-weight: var(--weight-medium);
+  color: var(--color-text-secondary);
+  background-color: transparent;
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-md);
+  cursor: pointer;
+  transition: color var(--transition-fast), border-color var(--transition-fast);
+}
+
+.btn-secondary:hover {
+  color: var(--color-text-primary);
+  border-color: var(--color-text-tertiary);
+}
+
+/* ==========================================================================
+   12. Loading & Error States
+   ========================================================================== */
 
 /* Loading indicator — animated "Thinking…" bubble */
 .message-loading {
   align-self: flex-start;
-  background-color: var(--color-bg-secondary);
+  background-color: var(--color-bg-tertiary);
   color: var(--color-text-secondary);
   font-style: italic;
   animation: pulse-opacity 1.4s ease-in-out infinite;
@@ -286,14 +801,54 @@ a:focus-visible {
 
 /* Error messages — left-aligned with error styling */
 .message-error {
-  background-color: #7f1d1d;
+  background-color: var(--color-error-bg);
   color: #fecaca;
-  border: 1px solid #991b1b;
-  border-bottom-left-radius: var(--radius-sm);
+  border: 1px solid rgba(239, 68, 68, 0.3);
+  border-bottom-left-radius: var(--radius-xs);
 }
 
 /* Disabled textarea while request is in-flight */
 .chat-textarea:disabled {
-  opacity: 0.6;
+  opacity: 0.5;
   cursor: not-allowed;
+}
+
+/* ==========================================================================
+   13. Responsive
+   ========================================================================== */
+@media (max-width: 768px) {
+  .sidebar {
+    position: fixed;
+    z-index: 50;
+    left: 0;
+    top: 0;
+    bottom: 0;
+    box-shadow: var(--shadow-lg);
+  }
+
+  .sidebar.sidebar-collapsed {
+    box-shadow: none;
+  }
+
+  .message-bubble {
+    max-width: 88%;
+  }
+
+  .chat-input-area {
+    flex-direction: column;
+  }
+
+  .send-btn {
+    width: 100%;
+  }
+
+  .scroll-area {
+    padding: var(--space-lg);
+  }
+}
+
+@media (max-width: 640px) {
+  :root {
+    --sidebar-width: 260px;
+  }
 }

--- a/server/Cargo.toml
+++ b/server/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "server"
-version = "0.10.0"
+version = "0.10.1"
 edition = "2021"
 
 [features]

--- a/server/Cargo.toml
+++ b/server/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "server"
-version = "0.9.0"
+version = "0.10.0"
 edition = "2021"
 
 [features]

--- a/server/src/lib.rs
+++ b/server/src/lib.rs
@@ -40,6 +40,7 @@ const DEFAULT_ALLOWED_ORIGINS: &[&str] = &[
 ///
 /// Routes:
 /// - `GET /health` — returns `{"status":"ok"}` with `200 OK`
+/// - `GET /api/models` — returns available models from the configured provider
 /// - `POST /api/chat/completions` — proxies non-streaming chat completions to
 ///   the configured provider
 /// - `POST /api/chat/completions/stream` — streams chat completions to the
@@ -67,6 +68,7 @@ pub fn app(state: AppState) -> Router {
 
     Router::new()
         .route("/health", get(routes::health::health))
+        .route("/api/models", get(routes::models::list_models))
         .route("/api/chat/completions", post(routes::chat::chat_completion))
         .route(
             "/api/chat/completions/stream",

--- a/server/src/providers/mod.rs
+++ b/server/src/providers/mod.rs
@@ -9,6 +9,13 @@ mod types;
 pub use openai::OpenAiProvider;
 pub use types::*;
 
+/// A single model returned by [`LlmProvider::list_models`].
+#[derive(Debug, Clone, serde::Serialize)]
+pub struct ModelInfo {
+    /// The model identifier (e.g. "llama3", "gpt-4o").
+    pub id: String,
+}
+
 use async_trait::async_trait;
 
 /// A trait that all LLM provider backends must implement.
@@ -34,6 +41,9 @@ pub trait LlmProvider: Send + Sync {
         tokio::sync::mpsc::Receiver<Result<ChatCompletionChunk, ProviderError>>,
         ProviderError,
     >;
+
+    /// List available models from this provider.
+    async fn list_models(&self) -> Result<Vec<ModelInfo>, ProviderError>;
 
     /// Human-readable name for this provider (e.g., "Ollama", "OpenAI").
     fn name(&self) -> &str;

--- a/server/src/providers/openai.rs
+++ b/server/src/providers/openai.rs
@@ -463,13 +463,20 @@ async fn process_sse_event(
 
 /// Truncate a byte slice to a string, limiting to `max_bytes`.
 /// Used for error response bodies that may be very large.
+/// Finds the last valid UTF-8 character boundary at or before `max_bytes`
+/// to avoid slicing in the middle of a multi-byte sequence.
 fn truncate_bytes_to_string(bytes: &[u8], max_bytes: usize) -> String {
-    let truncated = if bytes.len() > max_bytes {
-        &bytes[..max_bytes]
+    let limit = if bytes.len() > max_bytes {
+        // Walk backwards from max_bytes to find a valid UTF-8 char boundary.
+        let mut end = max_bytes;
+        while end > 0 && std::str::from_utf8(&bytes[..end]).is_err() {
+            end -= 1;
+        }
+        if end == 0 { max_bytes } else { end }
     } else {
-        bytes
+        bytes.len()
     };
-    String::from_utf8_lossy(truncated).into_owned()
+    String::from_utf8_lossy(&bytes[..limit]).into_owned()
 }
 
 #[cfg(test)]

--- a/server/src/providers/openai.rs
+++ b/server/src/providers/openai.rs
@@ -6,7 +6,8 @@
 //! [`tokio::sync::mpsc`] channel.
 
 use crate::providers::{
-    ChatCompletionChunk, ChatCompletionRequest, ChatCompletionResponse, LlmProvider, ProviderError,
+    ChatCompletionChunk, ChatCompletionRequest, ChatCompletionResponse, LlmProvider, ModelInfo,
+    ProviderError,
 };
 
 use async_trait::async_trait;
@@ -134,101 +135,15 @@ impl OpenAiProvider {
     }
 }
 
-/// Truncate a byte slice to `max_len` bytes, ensuring the result is valid
-/// UTF-8 by finding a char boundary. Appends "…" if truncation occurred.
-fn truncate_bytes_to_string(bytes: &[u8], max_len: usize) -> String {
-    if bytes.len() <= max_len {
-        return String::from_utf8_lossy(bytes).into_owned();
-    }
-
-    let mut end = max_len;
-    while end > 0 {
-        if bytes[end] & 0xC0 != 0x80 {
-            break;
-        }
-        end -= 1;
-    }
-    if end == 0 {
-        end = max_len;
-    }
-
-    let truncated = String::from_utf8_lossy(&bytes[..end]);
-    format!("{truncated}…")
-}
-
-/// Process all `data:` lines in a decoded SSE event string, sending parsed
-/// chunks through the channel.
-///
-/// Per the SSE specification, a `data:` field may optionally be followed by a
-/// single space before the value. Both `data:{"…"}` and `data: {"…"}` are
-/// accepted.
-///
-/// Returns `Ok(true)` if `[DONE]` was encountered, `Ok(false)` otherwise,
-/// or `Err(())` if the receiver was dropped.
-async fn process_sse_event(
-    event: &str,
-    tx: &mpsc::Sender<Result<ChatCompletionChunk, ProviderError>>,
-) -> Result<bool, ()> {
-    for line in event.lines() {
-        let line = line.trim_end();
-        if line.is_empty() {
-            continue;
-        }
-        if let Some(data) = line.strip_prefix("data:") {
-            // Per SSE spec, strip at most one leading space after "data:".
-            let data = data.strip_prefix(' ').unwrap_or(data);
-            if data == "[DONE]" {
-                return Ok(true);
-            }
-            match serde_json::from_str::<ChatCompletionChunk>(data) {
-                Ok(chunk) => {
-                    if tx.send(Ok(chunk)).await.is_err() {
-                        return Err(());
-                    }
-                }
-                Err(e) => {
-                    if tx
-                        .send(Err(ProviderError::InvalidResponse(format!(
-                            "failed to parse SSE chunk: {e}"
-                        ))))
-                        .await
-                        .is_err()
-                    {
-                        return Err(());
-                    }
-                }
-            }
-        }
-    }
-    Ok(false)
-}
-
 #[async_trait]
 impl LlmProvider for OpenAiProvider {
-    /// Send a non-streaming chat completion request.
-    ///
-    /// Builds the request body from the given [`ChatCompletionRequest`],
-    /// explicitly setting `stream: false`. Sends a `POST` to
-    /// `{base_url}/v1/chat/completions` with an `Authorization: Bearer`
-    /// header when an API key is configured.
-    ///
-    /// # Error mapping
-    ///
-    /// - HTTP 4xx/5xx → [`ProviderError::ApiError`]
-    /// - Connection refused / timeout → [`ProviderError::ConnectionFailed`]
-    /// - Malformed JSON → [`ProviderError::InvalidResponse`]
     async fn chat_completion(
         &self,
         request: ChatCompletionRequest,
     ) -> Result<ChatCompletionResponse, ProviderError> {
-        let mut body =
-            serde_json::to_value(&request).expect("failed to serialize ChatCompletionRequest");
-        body["stream"] = serde_json::Value::Bool(false);
-
         let url = format!("{}/v1/chat/completions", self.base_url);
 
-        let mut builder = self.client.post(&url).json(&body);
-
+        let mut builder = self.client.post(&url).json(&request);
         if let Some(ref key) = self.api_key {
             builder = builder.bearer_auth(key);
         }
@@ -252,40 +167,12 @@ impl LlmProvider for OpenAiProvider {
             });
         }
 
-        let response_text = response.text().await.map_err(|e| {
-            ProviderError::InvalidResponse(format!("failed to read response body: {e}"))
-        })?;
-
-        serde_json::from_str::<ChatCompletionResponse>(&response_text).map_err(|e| {
-            ProviderError::InvalidResponse(format!("failed to deserialize response: {e}"))
-        })
+        response
+            .json()
+            .await
+            .map_err(|e| ProviderError::InvalidResponse(e.to_string()))
     }
 
-    /// Send a streaming chat completion request via Server-Sent Events.
-    ///
-    /// Sends a `POST` to `{base_url}/v1/chat/completions` with
-    /// `"stream": true` in the request body. Reads the response as a byte
-    /// stream, parses SSE `data:` lines, and sends each parsed
-    /// [`ChatCompletionChunk`] through the returned mpsc channel.
-    ///
-    /// # SSE protocol
-    ///
-    /// - Each `data:` line contains a serialised `ChatCompletionChunk`.
-    /// - `data: [DONE]` signals end-of-stream; the channel is closed gracefully.
-    /// - Partial SSE lines that span multiple TCP chunks are buffered and
-    ///   reassembled before parsing.
-    /// - Malformed JSON sends `Err(InvalidResponse)` but does **not** terminate
-    ///   the stream.
-    ///
-    /// # Error mapping (initial request)
-    ///
-    /// - HTTP 4xx/5xx → [`ProviderError::ApiError`]
-    /// - Connection refused / timeout → [`ProviderError::ConnectionFailed`]
-    ///
-    /// # Error mapping (during streaming)
-    ///
-    /// - Bytes-stream error → [`ProviderError::ConnectionFailed`]
-    /// - Clean EOF without `[DONE]` → [`ProviderError::StreamEnded`]
     async fn chat_completion_stream(
         &self,
         request: ChatCompletionRequest,
@@ -379,8 +266,6 @@ impl LlmProvider for OpenAiProvider {
                 let remaining = String::from_utf8_lossy(&buffer);
                 let remaining = remaining.trim();
                 if !remaining.is_empty() {
-                    // Trimmed &str may yield InvalidResponse for partial JSON fragments,
-                    // but we intentionally continue to fallthrough and send StreamEnded.
                     match process_sse_event(remaining, &tx).await {
                         Ok(true) => return,
                         Ok(false) => {}
@@ -396,9 +281,125 @@ impl LlmProvider for OpenAiProvider {
         Ok(rx)
     }
 
+    /// List available models from the provider.
+    ///
+    /// Tries the OpenAI-compatible `/v1/models` endpoint first. If that
+    /// returns an empty list or fails, falls back to Ollama's native
+    /// `/api/tags` endpoint. Returns a list of [`ModelInfo`] with model
+    /// identifiers.
+    async fn list_models(&self) -> Result<Vec<ModelInfo>, ProviderError> {
+        // Try OpenAI-compatible /v1/models endpoint first.
+        let url = format!("{}/v1/models", self.base_url);
+
+        let mut builder = self.client.get(&url);
+        if let Some(ref key) = self.api_key {
+            builder = builder.bearer_auth(key);
+        }
+
+        let response = match builder.send().await {
+            Ok(r) => r,
+            Err(_e) => {
+                // Connection failed on /v1/models — try Ollama fallback.
+                return self.list_models_ollama().await;
+            }
+        };
+
+        if response.status().is_success() {
+            let body: serde_json::Value = response
+                .json()
+                .await
+                .map_err(|e| ProviderError::InvalidResponse(e.to_string()))?;
+
+            // OpenAI format: { "data": [ { "id": "model-name" }, ... ] }
+            if let Some(data) = body.get("data").and_then(|d| d.as_array()) {
+                let models: Vec<ModelInfo> = data
+                    .iter()
+                    .filter_map(|item| item.get("id").and_then(|id| id.as_str()))
+                    .map(|id| ModelInfo { id: id.to_string() })
+                    .collect();
+                if !models.is_empty() {
+                    return Ok(models);
+                }
+            }
+
+            // Some providers return a flat array of model names under "models".
+            if let Some(models_arr) = body.get("models").and_then(|m| m.as_array()) {
+                let models: Vec<ModelInfo> = models_arr
+                    .iter()
+                    .filter_map(|item| {
+                        item.as_str()
+                            .map(|s| ModelInfo { id: s.to_string() })
+                            .or_else(|| {
+                                item.get("id")
+                                    .and_then(|id| id.as_str())
+                                    .map(|s| ModelInfo { id: s.to_string() })
+                            })
+                    })
+                    .collect();
+                if !models.is_empty() {
+                    return Ok(models);
+                }
+            }
+        }
+
+        // Fallback: try Ollama's native /api/tags endpoint.
+        self.list_models_ollama().await
+    }
+
     /// Human-readable name for this provider.
     fn name(&self) -> &str {
         "OpenAI-compatible"
+    }
+}
+
+impl OpenAiProvider {
+    /// Fallback: list models via Ollama's native `/api/tags` endpoint.
+    async fn list_models_ollama(&self) -> Result<Vec<ModelInfo>, ProviderError> {
+        let url = format!("{}/api/tags", self.base_url);
+
+        let mut builder = self.client.get(&url);
+        if let Some(ref key) = self.api_key {
+            builder = builder.bearer_auth(key);
+        }
+
+        let response = builder
+            .send()
+            .await
+            .map_err(|e| ProviderError::ConnectionFailed(e.to_string()))?;
+
+        if !response.status().is_success() {
+            let status = response.status().as_u16();
+            let message = response
+                .bytes()
+                .await
+                .map(|b| truncate_bytes_to_string(&b, MAX_ERROR_BODY_BYTES))
+                .unwrap_or_else(|e| format!("(failed to read error body: {e})"));
+            return Err(ProviderError::ApiError { status, message });
+        }
+
+        let body: serde_json::Value = response
+            .json()
+            .await
+            .map_err(|e| ProviderError::InvalidResponse(e.to_string()))?;
+
+        // Ollama format: { "models": [ { "name": "llama3:latest", ... }, ... ] }
+        if let Some(models) = body.get("models").and_then(|m| m.as_array()) {
+            let model_list: Vec<ModelInfo> = models
+                .iter()
+                .filter_map(|item| {
+                    item.get("name")
+                        .and_then(|n| n.as_str())
+                        .map(|n| ModelInfo { id: n.to_string() })
+                })
+                .collect();
+            if !model_list.is_empty() {
+                return Ok(model_list);
+            }
+        }
+
+        Err(ProviderError::InvalidResponse(
+            "No models found from provider: both /v1/models and /api/tags returned empty or invalid responses".to_string(),
+        ))
     }
 }
 
@@ -415,4 +416,123 @@ fn find_event_delimiter(buffer: &[u8]) -> Option<(usize, usize)> {
         .windows(2)
         .position(|w| w == b"\n\n")
         .map(|pos| (pos, 2))
+}
+
+/// Process a single SSE event from the byte stream.
+///
+/// Returns `Ok(true)` if [DONE] was received (stream should end),
+/// `Ok(false)` if a normal chunk was processed, or `Err(())` if the
+/// receiver has been dropped.
+async fn process_sse_event(
+    event_text: &str,
+    tx: &mpsc::Sender<Result<ChatCompletionChunk, ProviderError>>,
+) -> Result<bool, ()> {
+    for line in event_text.lines() {
+        let line = line.trim();
+        if line.is_empty() || line.starts_with(':') {
+            continue;
+        }
+
+        if let Some(data) = line.strip_prefix("data:") {
+            let data = data.trim();
+            if data == "[DONE]" {
+                return Ok(true);
+            }
+            match serde_json::from_str::<ChatCompletionChunk>(data) {
+                Ok(chunk) => {
+                    if tx.send(Ok(chunk)).await.is_err() {
+                        return Err(());
+                    }
+                }
+                Err(e) => {
+                    if tx
+                        .send(Err(ProviderError::InvalidResponse(format!(
+                            "failed to parse SSE chunk: {e}"
+                        ))))
+                        .await
+                        .is_err()
+                    {
+                        return Err(());
+                    }
+                }
+            }
+        }
+    }
+    Ok(false)
+}
+
+/// Truncate a byte slice to a string, limiting to `max_bytes`.
+/// Used for error response bodies that may be very large.
+fn truncate_bytes_to_string(bytes: &[u8], max_bytes: usize) -> String {
+    let truncated = if bytes.len() > max_bytes {
+        &bytes[..max_bytes]
+    } else {
+        bytes
+    };
+    String::from_utf8_lossy(truncated).into_owned()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_default_model_constant() {
+        assert_eq!(DEFAULT_MODEL, "llama3");
+    }
+
+    #[test]
+    fn test_provider_new_trims_trailing_slash() {
+        let provider = OpenAiProvider::new(
+            "http://localhost:11434/".to_string(),
+            None,
+            "test-model".to_string(),
+        );
+        assert_eq!(provider.base_url(), "http://localhost:11434");
+    }
+
+    #[test]
+    fn test_provider_new_strips_empty_api_key() {
+        let provider = OpenAiProvider::new(
+            "http://localhost:11434".to_string(),
+            Some("".to_string()),
+            "test-model".to_string(),
+        );
+        assert!(provider.api_key().is_none());
+    }
+
+    #[test]
+    fn test_provider_new_keeps_nonempty_api_key() {
+        let provider = OpenAiProvider::new(
+            "http://localhost:11434".to_string(),
+            Some("sk-test".to_string()),
+            "test-model".to_string(),
+        );
+        assert_eq!(provider.api_key(), Some("sk-test"));
+    }
+
+    #[test]
+    fn test_find_event_delimiter_double_newline() {
+        assert_eq!(find_event_delimiter(b"hello\n\nworld"), Some((5, 2)));
+    }
+
+    #[test]
+    fn test_find_event_delimiter_crlf_crlf() {
+        assert_eq!(find_event_delimiter(b"hello\r\n\r\nworld"), Some((5, 4)));
+    }
+
+    #[test]
+    fn test_find_event_delimiter_none() {
+        assert_eq!(find_event_delimiter(b"no delimiter here"), None);
+    }
+
+    #[test]
+    fn test_truncate_bytes_to_string_short() {
+        assert_eq!(truncate_bytes_to_string(b"hello", 100), "hello");
+    }
+
+    #[test]
+    fn test_truncate_bytes_to_string_truncated() {
+        assert_eq!(truncate_bytes_to_string(b"hello world", 5), "hello");
+    }
 }

--- a/server/src/routes/mod.rs
+++ b/server/src/routes/mod.rs
@@ -4,3 +4,4 @@ pub mod chat;
 pub mod chat_stream;
 pub mod error;
 pub mod health;
+pub mod models;

--- a/server/src/routes/models.rs
+++ b/server/src/routes/models.rs
@@ -4,6 +4,7 @@
 //! configured LLM provider.
 
 use crate::providers::ModelInfo;
+use crate::routes::error::{error_response, map_provider_error};
 use crate::state::AppState;
 use axum::extract::State;
 use axum::http::StatusCode;
@@ -27,12 +28,9 @@ pub async fn list_models(State(state): State<AppState>) -> impl IntoResponse {
             (StatusCode::OK, axum::Json(ModelsResponse { models })).into_response()
         }
         Err(error) => {
-            error!(error = %error, "failed to list models");
-            (
-                StatusCode::BAD_GATEWAY,
-                axum::Json(serde_json::json!({ "error": error.to_string() })),
-            )
-                .into_response()
+            let (status, message) = map_provider_error(&error);
+            error!(status = %status, error = %error, "failed to list models");
+            error_response(status, message)
         }
     }
 }

--- a/server/src/routes/models.rs
+++ b/server/src/routes/models.rs
@@ -1,0 +1,38 @@
+//! Models API route handler.
+//!
+//! `GET /api/models` — returns the list of available models from the
+//! configured LLM provider.
+
+use crate::providers::ModelInfo;
+use crate::state::AppState;
+use axum::extract::State;
+use axum::http::StatusCode;
+use axum::response::IntoResponse;
+use serde::Serialize;
+use tracing::{error, info};
+
+/// JSON response payload for the models list endpoint.
+#[derive(Serialize)]
+pub struct ModelsResponse {
+    pub models: Vec<ModelInfo>,
+}
+
+/// `GET /api/models` — returns available models from the configured provider.
+pub async fn list_models(State(state): State<AppState>) -> impl IntoResponse {
+    info!("listing available models");
+
+    match state.provider.list_models().await {
+        Ok(models) => {
+            info!(count = models.len(), "listed models");
+            (StatusCode::OK, axum::Json(ModelsResponse { models })).into_response()
+        }
+        Err(error) => {
+            error!(error = %error, "failed to list models");
+            (
+                StatusCode::BAD_GATEWAY,
+                axum::Json(serde_json::json!({ "error": error.to_string() })),
+            )
+                .into_response()
+        }
+    }
+}

--- a/server/src/state.rs
+++ b/server/src/state.rs
@@ -1,7 +1,7 @@
 //! Shared application state for the Axum server.
 
 use crate::providers::{
-    ChatCompletionChunk, ChatCompletionRequest, ChatCompletionResponse, LlmProvider,
+    ChatCompletionChunk, ChatCompletionRequest, ChatCompletionResponse, LlmProvider, ModelInfo,
     OpenAiProvider, ProviderError,
 };
 use async_trait::async_trait;
@@ -54,6 +54,12 @@ impl LlmProvider for NoopProvider {
         &self,
         _request: ChatCompletionRequest,
     ) -> Result<mpsc::Receiver<Result<ChatCompletionChunk, ProviderError>>, ProviderError> {
+        Err(ProviderError::ConnectionFailed(
+            "LLM provider not configured for this AppState".to_string(),
+        ))
+    }
+
+    async fn list_models(&self) -> Result<Vec<ModelInfo>, ProviderError> {
         Err(ProviderError::ConnectionFailed(
             "LLM provider not configured for this AppState".to_string(),
         ))

--- a/server/tests/chat_completions.rs
+++ b/server/tests/chat_completions.rs
@@ -7,7 +7,7 @@ use http_body_util::BodyExt;
 use server::app;
 use server::providers::{
     ChatCompletionChunk, ChatCompletionRequest, ChatCompletionResponse, ChatMessage, Choice,
-    LlmProvider, MessageRole, ProviderError, Usage,
+    LlmProvider, MessageRole, ModelInfo, ProviderError, Usage,
 };
 use server::state::AppState;
 use std::sync::{Arc, Mutex};
@@ -96,6 +96,12 @@ impl LlmProvider for MockProvider {
         _request: ChatCompletionRequest,
     ) -> Result<mpsc::Receiver<Result<ChatCompletionChunk, ProviderError>>, ProviderError> {
         Err(ProviderError::StreamingNotSupported)
+    }
+
+    async fn list_models(&self) -> Result<Vec<ModelInfo>, ProviderError> {
+        Ok(vec![ModelInfo {
+            id: "test-model".to_string(),
+        }])
     }
 
     fn name(&self) -> &str {

--- a/server/tests/chat_completions_stream.rs
+++ b/server/tests/chat_completions_stream.rs
@@ -7,7 +7,7 @@ use http_body_util::BodyExt;
 use server::app;
 use server::providers::{
     ChatCompletionChunk, ChatCompletionRequest, ChatCompletionResponse, ChatMessage, ChunkChoice,
-    ChunkDelta, LlmProvider, MessageRole, ProviderError,
+    ChunkDelta, LlmProvider, MessageRole, ModelInfo, ProviderError,
 };
 use server::state::AppState;
 use std::sync::{Arc, Mutex};
@@ -97,6 +97,12 @@ impl LlmProvider for StreamMockProvider {
         });
 
         Ok(rx)
+    }
+
+    async fn list_models(&self) -> Result<Vec<ModelInfo>, ProviderError> {
+        Ok(vec![ModelInfo {
+            id: "test-model".to_string(),
+        }])
     }
 
     fn name(&self) -> &str {

--- a/server/tests/css_design_system.rs
+++ b/server/tests/css_design_system.rs
@@ -89,27 +89,27 @@ fn test_css_custom_property_values() {
     // Verify exact assignments for key colour tokens
     let value_checks = [
         (
-            r"--color-bg-primary:\s*#111827",
+            r"--color-bg-primary:\s*#0a0a0b",
             "--color-bg-primary",
-            "#111827",
+            "#0a0a0b",
         ),
         (
-            r"--color-bg-secondary:\s*#1f2937",
+            r"--color-bg-secondary:\s*#141416",
             "--color-bg-secondary",
-            "#1f2937",
+            "#141416",
         ),
         (
-            r"--color-bg-input:\s*#374151",
+            r"--color-bg-input:\s*#1e1e23",
             "--color-bg-input",
-            "#374151",
+            "#1e1e23",
         ),
-        (r"--color-accent:\s*#3b82f6", "--color-accent", "#3b82f6"),
+        (r"--color-accent:\s*#a78bfa", "--color-accent", "#a78bfa"),
         (
-            r"--color-accent-hover:\s*#2563eb",
+            r"--color-accent-hover:\s*#8b6ff0",
             "--color-accent-hover",
-            "#2563eb",
+            "#8b6ff0",
         ),
-        (r"--color-border:\s*#4b5563", "--color-border", "#4b5563"),
+        (r"--color-border:\s*#222228", "--color-border", "#222228"),
     ];
 
     for (pattern, var, value) in &value_checks {
@@ -261,9 +261,12 @@ fn test_app_component_uses_app_root_class() {
     let lib_rs = read_app_lib_rs();
 
     assert!(
-        regex::Regex::new(r#"class="[^"]*\bapp-root\b[^"]*""#)
+        (regex::Regex::new(r#"class="[^"]*\bapp-layout\b[^"]*""#)
             .expect("invalid regex")
-            .is_match(&lib_rs),
-        "Leptos App component must apply class=\"app-root\" to its root element"
+            .is_match(&lib_rs)
+            || regex::Regex::new(r#"class="[^"]*\bapp-root\b[^"]*""#)
+                .expect("invalid regex")
+                .is_match(&lib_rs)),
+        "Leptos App component must apply class=\"app-layout\" or \"app-root\" to its root element"
     );
 }

--- a/server/tests/frontend_api_integration.rs
+++ b/server/tests/frontend_api_integration.rs
@@ -63,10 +63,7 @@ fn workspace_root() -> &'static Path {
                 }
             }
             dir = dir.parent().unwrap_or_else(|| {
-                panic!(
-                    "could not find workspace Cargo.toml above {}",
-                    manifest_dir
-                )
+                panic!("could not find workspace Cargo.toml above {}", manifest_dir)
             });
         }
     });
@@ -199,10 +196,12 @@ fn test_chat_message_has_is_error_field() {
 fn test_chat_view_uses_loading_signal() {
     let source = read_file("frontend/src/components/chat.rs");
     assert!(
-        Regex::new(r"let\s*\(.*\bloading\b.*\).*signal\s*\(\s*false\s*\)").unwrap().is_match(
-            &extract_function_body(&source, "ChatView")
-                .expect("ChatView function must exist in chat.rs"),
-        ),
+        Regex::new(r"let\s*\(.*\bloading\b.*\).*signal\s*\(\s*false\s*\)")
+            .unwrap()
+            .is_match(
+                &extract_function_body(&source, "ChatView")
+                    .expect("ChatView function must exist in chat.rs"),
+            ),
         "ChatView must declare `let (loading, …) = signal(false)`"
     );
 }

--- a/server/tests/provider_trait_tests.rs
+++ b/server/tests/provider_trait_tests.rs
@@ -109,6 +109,14 @@ async fn test_mock_provider_chat_completion_stream() {
 }
 
 #[tokio::test]
+async fn test_mock_provider_list_models() {
+    let provider = MockProvider;
+    let models = provider.list_models().await.unwrap();
+    assert_eq!(models.len(), 1);
+    assert_eq!(models[0].id, "test-model");
+}
+
+#[tokio::test]
 async fn test_provider_error_display() {
     let err = ProviderError::ConnectionFailed("timeout".to_string());
     assert_eq!(format!("{err}"), "Connection failed: timeout");

--- a/server/tests/provider_trait_tests.rs
+++ b/server/tests/provider_trait_tests.rs
@@ -3,7 +3,7 @@
 use async_trait::async_trait;
 use server::providers::{
     ChatCompletionChunk, ChatCompletionRequest, ChatCompletionResponse, ChatMessage, Choice,
-    ChunkChoice, ChunkDelta, LlmProvider, MessageRole, ProviderError, Usage,
+    ChunkChoice, ChunkDelta, LlmProvider, MessageRole, ModelInfo, ProviderError, Usage,
 };
 use tokio::sync::mpsc;
 
@@ -57,6 +57,12 @@ impl LlmProvider for MockProvider {
         });
 
         Ok(rx)
+    }
+
+    async fn list_models(&self) -> Result<Vec<ModelInfo>, ProviderError> {
+        Ok(vec![ModelInfo {
+            id: "test-model".to_string(),
+        }])
     }
 
     fn name(&self) -> &str {


### PR DESCRIPTION
## Summary

Complete redesign of the chat UI adding thread management, settings configuration, and dynamic model selection.

### Features Added

**Collapsible Sidebar**
- Left panel listing all chat threads with active-thread highlighting
- "New Chat" button to create threads
- Per-thread delete button (appears on hover)
- Collapses to icon-only width; settings button at bottom

**Settings Modal**
- API endpoint URL input (e.g. `http://localhost:11434` for Ollama, `https://api.openai.com` for OpenAI)
- Optional auth key with show/hide toggle
- Changes saved to in-memory state; no persistence layer yet (Phase 2)

**Dynamic Model Selector**
- Dropdown in the chat header fetches available models from `GET /api/models`
- No hardcoded model presets — models come from the provider
- "Custom…" option allows free-form model name entry
- Selected model persists across new chats until changed

**Backend: `list_models()` Provider Method**
- New `list_models()` method on `LlmProvider` trait
- `OpenAiProvider` tries `/v1/models` (OpenAI-compatible) first, falls back to `/api/tags` (Ollama native)
- New `GET /api/models` route returning `Vec<ModelInfo>`
- `NoopProvider` returns a connection error (consistent with existing pattern)

**Premium Dark Theme**
- Deep black backgrounds (`#0a0a0b`, `#141416`), muted lavender accent (`#a78bfa`)
- System font stack (`system-ui, -apple-system, sans-serif`) for native feel
- Thin 4px scrollbars, subtle borders, smooth transitions
- No heavy cards or wells — clean, minimal surfaces

### API Changes

- `send_chat_request()` now accepts `endpoint` and `auth_key` params instead of relying on `window.__LIBRECHAT_API_URL__`
- `fetch_models()` added for dynamic model listing
- Bearer auth header included when auth key is set

### Versioning

- Frontend: `0.4.0` → `0.5.0` (new UI components, breaking API change to `send_chat_request`)
- Server: `0.9.0` → `0.10.0` (new trait method, new route)

### Testing

All 132 existing tests pass. Updated CSS design-token assertions and provider-trait mock implementations for the new `list_models` method.

### Screenshots

N/A — WASM frontend requires `trunk build` to preview. The UI features:
- Collapsible sidebar (280px → 52px) with thread list
- Centered model dropdown in chat header
- Welcome screen when no thread is active
- Settings modal with endpoint/auth configuration

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * End-to-end model discovery: server API for listing models, provider support, client fetch and ModelSelector UI with refresh/loading/error and custom model input.
  * Global app state, multi-thread chats, sidebar for thread navigation and per-thread history; updated send/response flow and settings modal.

* **Style**
  * New premium-dark theme, updated layout, sidebar and chat/message styling, revised responsive breakpoints.

* **Documentation**
  * Contributing: branch naming convention added.

* **Tests**
  * Tests updated for model listing and CSS/component expectations.

* **Chores**
  * Frontend and server package version bumps.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->