### PR TITLE
feat: add SQLite persistence foundation with SQLx

### DIFF
--- a/.sqlx/query-c93b38123d0a623596cfcaf14a467b9ba4c71b403264b289e0ecdd714cc51d08.json
+++ b/.sqlx/query-c93b38123d0a623596cfcaf14a467b9ba4c71b403264b289e0ecdd714cc51d08.json
@@ -1,0 +1,20 @@
+{
+  "db_name": "SQLite",
+  "query": "SELECT COUNT(*) as count FROM sqlite_master WHERE type = 'table' AND name = ?1",
+  "describe": {
+    "columns": [
+      {
+        "name": "count",
+        "ordinal": 0,
+        "type_info": "Integer"
+      }
+    ],
+    "parameters": {
+      "Right": 1
+    },
+    "nullable": [
+      false
+    ]
+  },
+  "hash": "c93b38123d0a623596cfcaf14a467b9ba4c71b403264b289e0ecdd714cc51d08"
+}

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -12,6 +12,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "allocator-api2"
+version = "0.2.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "683d7910e743518b0e34f1186f92494becacb047c7b6bf616c96772180fef923"
+
+[[package]]
 name = "any_spawner"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -57,6 +63,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "atoi"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f28d99ec8bfea296261ca1af174f24225171fea9664ba9003cbebee704810528"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
 name = "atomic-waker"
 version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -91,6 +106,12 @@ dependencies = [
  "quote-use",
  "syn",
 ]
+
+[[package]]
+name = "autocfg"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
 
 [[package]]
 name = "axum"
@@ -157,10 +178,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
 
 [[package]]
+name = "base64ct"
+version = "1.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2af50177e190e07a26ab74f8b1efbfe2ef87da2116221318cb1c2e82baf7de06"
+
+[[package]]
 name = "bitflags"
 version = "2.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c4512299f36f043ab09a583e57bceb5a5aab7a73db1805848e8fef3c9e8c78b3"
+dependencies = [
+ "serde_core",
+]
 
 [[package]]
 name = "block-buffer"
@@ -176,6 +206,12 @@ name = "bumpalo"
 version = "3.20.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5d20789868f4b01b2f2caec9f5c4e0213b41e3e5702a50157d699ae31ced2fcb"
+
+[[package]]
+name = "byteorder"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
 
 [[package]]
 name = "bytes"
@@ -243,6 +279,12 @@ dependencies = [
  "toml 1.1.2+spec-1.1.0",
  "winnow 1.0.2",
 ]
+
+[[package]]
+name = "const-oid"
+version = "0.9.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c2459377285ad874054d797f3ccebf984978aa39129f6eafde5cdc8315b612f8"
 
 [[package]]
 name = "const-str"
@@ -340,6 +382,30 @@ dependencies = [
 ]
 
 [[package]]
+name = "crc"
+version = "3.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5eb8a2a1cd12ab0d987a5d5e825195d372001a4094a0376319d5a0ad71c1ba0d"
+dependencies = [
+ "crc-catalog",
+]
+
+[[package]]
+name = "crc-catalog"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "217698eaf96b4a3f0bc4f3662aaa55bdf913cd54d7204591faa790070c6d0853"
+
+[[package]]
+name = "crossbeam-queue"
+version = "0.3.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0f58bbc28f91df819d0aa2a2c00cd19754769c2fad90579b3592b1c9ba7a3115"
+dependencies = [
+ "crossbeam-utils",
+]
+
+[[package]]
 name = "crossbeam-utils"
 version = "0.8.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -353,6 +419,17 @@ checksum = "78c8292055d1c1df0cce5d180393dc8cce0abec0a7102adb6c7b1eef6016d60a"
 dependencies = [
  "generic-array",
  "typenum",
+]
+
+[[package]]
+name = "der"
+version = "0.7.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e7c1832837b905bbfb5101e07cc24c8deddf52f93225eee6ead5f4d63d53ddcb"
+dependencies = [
+ "const-oid",
+ "pem-rfc7468",
+ "zeroize",
 ]
 
 [[package]]
@@ -373,7 +450,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
 dependencies = [
  "block-buffer",
+ "const-oid",
  "crypto-common",
+ "subtle",
 ]
 
 [[package]]
@@ -388,6 +467,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "dotenvy"
+version = "0.15.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1aaf95b3e5c8f23aa320147307562d361db0ae0d51242340f558153b4eb2439b"
+
+[[package]]
 name = "drain_filter_polyfill"
 version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -398,6 +483,9 @@ name = "either"
 version = "1.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
+dependencies = [
+ "serde",
+]
 
 [[package]]
 name = "either_of"
@@ -441,6 +529,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "etcetera"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "136d1b5283a1ab77bd9257427ffd09d8667ced0570b6f938942bc7568ed5b943"
+dependencies = [
+ "cfg-if",
+ "home",
+ "windows-sys 0.48.0",
+]
+
+[[package]]
 name = "event-listener"
 version = "5.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -472,6 +571,17 @@ name = "find-msvc-tools"
 version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5baebc0774151f905a1a2cc41989300b1e6fbb29aff0ceffa1064fdd3088d582"
+
+[[package]]
+name = "flume"
+version = "0.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "da0e4dd2a88388a1f4ccc7c9ce104604dab68d9f408dc34cd45823d5a9069095"
+dependencies = [
+ "futures-core",
+ "futures-sink",
+ "spin",
+]
 
 [[package]]
 name = "fnv"
@@ -563,6 +673,17 @@ dependencies = [
  "futures-core",
  "futures-task",
  "futures-util",
+]
+
+[[package]]
+name = "futures-intrusive"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d930c203dd0b6ff06e0201a4a2fe9149b43c684fd4420555b26d21b1a02956f"
+dependencies = [
+ "futures-core",
+ "lock_api",
+ "parking_lot",
 ]
 
 [[package]]
@@ -712,6 +833,8 @@ version = "0.15.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1"
 dependencies = [
+ "allocator-api2",
+ "equivalent",
  "foldhash",
 ]
 
@@ -722,10 +845,52 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4f467dd6dccf739c208452f8014c75c18bb8301b050ad1cfb27153803edb0f51"
 
 [[package]]
+name = "hashlink"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7382cf6263419f2d8df38c55d7da83da5c18aef87fc7a7fc1fb1e344edfe14c1"
+dependencies = [
+ "hashbrown 0.15.5",
+]
+
+[[package]]
 name = "heck"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
+
+[[package]]
+name = "hex"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
+
+[[package]]
+name = "hkdf"
+version = "0.12.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b5f8eb2ad728638ea2c7d47a21db23b7b58a72ed6a38256b8a1849f15fbbdf7"
+dependencies = [
+ "hmac",
+]
+
+[[package]]
+name = "hmac"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c49c37c09c17a53d937dfbb742eb3a961d65a994e6bcdcf37e7399d0cc8ab5e"
+dependencies = [
+ "digest",
+]
+
+[[package]]
+name = "home"
+version = "0.5.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cc627f471c528ff0c4a49e1d5e60450c8f6461dd6d10ba9dcd3a61d3dff7728d"
+dependencies = [
+ "windows-sys 0.61.2",
+]
 
 [[package]]
 name = "html-escape"
@@ -1069,6 +1234,9 @@ name = "lazy_static"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
+dependencies = [
+ "spin",
+]
 
 [[package]]
 name = "leb128fmt"
@@ -1213,6 +1381,35 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "52ff2c0fe9bc6cb6b14a0592c2ff4fa9ceb83eea9db979b0487cd054946a2b8f"
 
 [[package]]
+name = "libm"
+version = "0.2.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6d2cec3eae94f9f509c767b45932f1ada8350c4bdb85af2fcab4a3c14807981"
+
+[[package]]
+name = "libredox"
+version = "0.1.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e02f3bb43d335493c96bf3fd3a321600bf6bd07ed34bc64118e9293bdffea46c"
+dependencies = [
+ "bitflags",
+ "libc",
+ "plain",
+ "redox_syscall 0.7.5",
+]
+
+[[package]]
+name = "libsqlite3-sys"
+version = "0.30.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2e99fb7a497b1e3339bc746195567ed8d3e24945ecd636e3619d20b9de9e9149"
+dependencies = [
+ "cc",
+ "pkg-config",
+ "vcpkg",
+]
+
+[[package]]
 name = "linux-raw-sys"
 version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1278,6 +1475,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "47e1ffaa40ddd1f3ed91f717a33c8c0ee23fff369e3aa8772b9605cc1d22f4c3"
 
 [[package]]
+name = "md-5"
+version = "0.10.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d89e7ee0cfbedfc4da3340218492196241d89eefb6dab27de5df917a6d2e78cf"
+dependencies = [
+ "cfg-if",
+ "digest",
+]
+
+[[package]]
 name = "memchr"
 version = "2.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1340,6 +1547,52 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "num-bigint-dig"
+version = "0.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e661dda6640fad38e827a6d4a310ff4763082116fe217f279885c97f511bb0b7"
+dependencies = [
+ "lazy_static",
+ "libm",
+ "num-integer",
+ "num-iter",
+ "num-traits",
+ "rand",
+ "smallvec",
+ "zeroize",
+]
+
+[[package]]
+name = "num-integer"
+version = "0.1.46"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7969661fd2958a5cb096e56c8e1ad0444ac2bbcd0061bd28660485a44879858f"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
+name = "num-iter"
+version = "0.1.45"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1429034a0490724d0075ebb2bc9e875d6503c3cf69e235a8941aa757d83ef5bf"
+dependencies = [
+ "autocfg",
+ "num-integer",
+ "num-traits",
+]
+
+[[package]]
+name = "num-traits"
+version = "0.2.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
+dependencies = [
+ "autocfg",
+ "libm",
 ]
 
 [[package]]
@@ -1432,7 +1685,7 @@ checksum = "2621685985a2ebf1c516881c026032ac7deafcda1a2c9b7850dc81e3dfcb64c1"
 dependencies = [
  "cfg-if",
  "libc",
- "redox_syscall",
+ "redox_syscall 0.5.18",
  "smallvec",
  "windows-link",
 ]
@@ -1448,6 +1701,15 @@ name = "pathdiff"
 version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "df94ce210e5bc13cb6651479fa48d14f601d9858cfe0467f43ae157023b938d3"
+
+[[package]]
+name = "pem-rfc7468"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "88b39c9bfcfc231068454382784bb460aae594343fb030d46e9f50a645418412"
+dependencies = [
+ "base64ct",
+]
 
 [[package]]
 name = "percent-encoding"
@@ -1482,10 +1744,37 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
 
 [[package]]
+name = "pkcs1"
+version = "0.7.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c8ffb9f10fa047879315e6625af03c164b16962a5368d724ed16323b68ace47f"
+dependencies = [
+ "der",
+ "pkcs8",
+ "spki",
+]
+
+[[package]]
+name = "pkcs8"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f950b2377845cebe5cf8b5165cb3cc1a5e0fa5cfa3e1f7f55707d8fd82e0a7b7"
+dependencies = [
+ "der",
+ "spki",
+]
+
+[[package]]
 name = "pkg-config"
 version = "0.3.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "19f132c84eca552bf34cab8ec81f1c1dcc229b811638f9d283dceabe58c5569e"
+
+[[package]]
+name = "plain"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b4596b6d070b27117e987119b4dac604f3c58cfb0b191112e24771b2faeac1a6"
 
 [[package]]
 name = "potential_utf"
@@ -1494,6 +1783,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0103b1cef7ec0cf76490e969665504990193874ea05c85ff9bab8b911d0a0564"
 dependencies = [
  "zerovec",
+]
+
+[[package]]
+name = "ppv-lite86"
+version = "0.2.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85eae3c4ed2f50dcfe72643da4befc30deadb458a9b590d720cde2f2b1e97da9"
+dependencies = [
+ "zerocopy",
 ]
 
 [[package]]
@@ -1599,6 +1897,36 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
 
 [[package]]
+name = "rand"
+version = "0.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5ca0ecfa931c29007047d1bc58e623ab12e5590e8c7cc53200d5202b69266d8a"
+dependencies = [
+ "libc",
+ "rand_chacha",
+ "rand_core",
+]
+
+[[package]]
+name = "rand_chacha"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88"
+dependencies = [
+ "ppv-lite86",
+ "rand_core",
+]
+
+[[package]]
+name = "rand_core"
+version = "0.6.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
+dependencies = [
+ "getrandom 0.2.17",
+]
+
+[[package]]
 name = "reactive_graph"
 version = "0.2.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1657,6 +1985,15 @@ name = "redox_syscall"
 version = "0.5.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed2bf2547551a7053d6fdfafda3f938979645c44812fbfcda098faae3f1a362d"
+dependencies = [
+ "bitflags",
+]
+
+[[package]]
+name = "redox_syscall"
+version = "0.7.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4666a1a60d8412eab19d94f6d13dcc9cea0a5ef4fdf6a5db306537413c661b1b"
 dependencies = [
  "bitflags",
 ]
@@ -1745,6 +2082,26 @@ dependencies = [
  "libc",
  "untrusted",
  "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "rsa"
+version = "0.9.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8573f03f5883dcaebdfcf4725caa1ecb9c15b2ef50c43a07b816e06799bb12d"
+dependencies = [
+ "const-oid",
+ "digest",
+ "num-bigint-dig",
+ "num-integer",
+ "num-traits",
+ "pkcs1",
+ "pkcs8",
+ "rand_core",
+ "signature",
+ "spki",
+ "subtle",
+ "zeroize",
 ]
 
 [[package]]
@@ -2005,6 +2362,7 @@ dependencies = [
  "reqwest",
  "serde",
  "serde_json",
+ "sqlx",
  "tempfile",
  "tokio",
  "toml 0.8.23",
@@ -2073,6 +2431,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "sha1"
+version = "0.10.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3bf829a2d51ab4a5ddf1352d8470c140cadc8301b2ae1789db023f01cedd6ba"
+dependencies = [
+ "cfg-if",
+ "cpufeatures",
+ "digest",
+]
+
+[[package]]
 name = "sha2"
 version = "0.10.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2109,6 +2478,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "signature"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77549399552de45a898a580c1b41d445bf730df867cc44e6c0233bbc4b8329de"
+dependencies = [
+ "digest",
+ "rand_core",
+]
+
+[[package]]
 name = "slab"
 version = "0.4.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2128,6 +2507,9 @@ name = "smallvec"
 version = "1.15.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
+dependencies = [
+ "serde",
+]
 
 [[package]]
 name = "socket2"
@@ -2140,10 +2522,225 @@ dependencies = [
 ]
 
 [[package]]
+name = "spin"
+version = "0.9.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6980e8d7511241f8acf4aebddbb1ff938df5eebe98691418c4468d0b72a96a67"
+dependencies = [
+ "lock_api",
+]
+
+[[package]]
+name = "spki"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d91ed6c858b01f942cd56b37a94b3e0a1798290327d1236e4d9cf4eaca44d29d"
+dependencies = [
+ "base64ct",
+ "der",
+]
+
+[[package]]
+name = "sqlx"
+version = "0.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1fefb893899429669dcdd979aff487bd78f4064e5e7907e4269081e0ef7d97dc"
+dependencies = [
+ "sqlx-core",
+ "sqlx-macros",
+ "sqlx-mysql",
+ "sqlx-postgres",
+ "sqlx-sqlite",
+]
+
+[[package]]
+name = "sqlx-core"
+version = "0.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ee6798b1838b6a0f69c007c133b8df5866302197e404e8b6ee8ed3e3a5e68dc6"
+dependencies = [
+ "base64",
+ "bytes",
+ "crc",
+ "crossbeam-queue",
+ "either",
+ "event-listener",
+ "futures-core",
+ "futures-intrusive",
+ "futures-io",
+ "futures-util",
+ "hashbrown 0.15.5",
+ "hashlink",
+ "indexmap",
+ "log",
+ "memchr",
+ "once_cell",
+ "percent-encoding",
+ "serde",
+ "serde_json",
+ "sha2",
+ "smallvec",
+ "thiserror 2.0.18",
+ "tokio",
+ "tokio-stream",
+ "tracing",
+ "url",
+]
+
+[[package]]
+name = "sqlx-macros"
+version = "0.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a2d452988ccaacfbf5e0bdbc348fb91d7c8af5bee192173ac3636b5fb6e6715d"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "sqlx-core",
+ "sqlx-macros-core",
+ "syn",
+]
+
+[[package]]
+name = "sqlx-macros-core"
+version = "0.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "19a9c1841124ac5a61741f96e1d9e2ec77424bf323962dd894bdb93f37d5219b"
+dependencies = [
+ "dotenvy",
+ "either",
+ "heck",
+ "hex",
+ "once_cell",
+ "proc-macro2",
+ "quote",
+ "serde",
+ "serde_json",
+ "sha2",
+ "sqlx-core",
+ "sqlx-sqlite",
+ "syn",
+ "tokio",
+ "url",
+]
+
+[[package]]
+name = "sqlx-mysql"
+version = "0.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aa003f0038df784eb8fecbbac13affe3da23b45194bd57dba231c8f48199c526"
+dependencies = [
+ "atoi",
+ "base64",
+ "bitflags",
+ "byteorder",
+ "bytes",
+ "crc",
+ "digest",
+ "dotenvy",
+ "either",
+ "futures-channel",
+ "futures-core",
+ "futures-io",
+ "futures-util",
+ "generic-array",
+ "hex",
+ "hkdf",
+ "hmac",
+ "itoa",
+ "log",
+ "md-5",
+ "memchr",
+ "once_cell",
+ "percent-encoding",
+ "rand",
+ "rsa",
+ "sha1",
+ "sha2",
+ "smallvec",
+ "sqlx-core",
+ "stringprep",
+ "thiserror 2.0.18",
+ "tracing",
+ "whoami",
+]
+
+[[package]]
+name = "sqlx-postgres"
+version = "0.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "db58fcd5a53cf07c184b154801ff91347e4c30d17a3562a635ff028ad5deda46"
+dependencies = [
+ "atoi",
+ "base64",
+ "bitflags",
+ "byteorder",
+ "crc",
+ "dotenvy",
+ "etcetera",
+ "futures-channel",
+ "futures-core",
+ "futures-util",
+ "hex",
+ "hkdf",
+ "hmac",
+ "home",
+ "itoa",
+ "log",
+ "md-5",
+ "memchr",
+ "once_cell",
+ "rand",
+ "serde",
+ "serde_json",
+ "sha2",
+ "smallvec",
+ "sqlx-core",
+ "stringprep",
+ "thiserror 2.0.18",
+ "tracing",
+ "whoami",
+]
+
+[[package]]
+name = "sqlx-sqlite"
+version = "0.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c2d12fe70b2c1b4401038055f90f151b78208de1f9f89a7dbfd41587a10c3eea"
+dependencies = [
+ "atoi",
+ "flume",
+ "futures-channel",
+ "futures-core",
+ "futures-executor",
+ "futures-intrusive",
+ "futures-util",
+ "libsqlite3-sys",
+ "log",
+ "percent-encoding",
+ "serde",
+ "serde_urlencoded",
+ "sqlx-core",
+ "thiserror 2.0.18",
+ "tracing",
+ "url",
+]
+
+[[package]]
 name = "stable_deref_trait"
 version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6ce2be8dc25455e1f91df71bfa12ad37d7af1092ae736f3a6cd0e37bc7810596"
+
+[[package]]
+name = "stringprep"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b4df3d392d81bd458a8a621b8bffbd2302a12ffe288a9d931670948749463b1"
+dependencies = [
+ "unicode-bidi",
+ "unicode-normalization",
+ "unicode-properties",
+]
 
 [[package]]
 name = "subtle"
@@ -2329,6 +2926,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "tinyvec"
+version = "1.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3e61e67053d25a4e82c844e8424039d9745781b3fc4f32b8d55ed50f5f667ef3"
+dependencies = [
+ "tinyvec_macros",
+]
+
+[[package]]
+name = "tinyvec_macros"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
+
+[[package]]
 name = "tokio"
 version = "1.52.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2373,6 +2985,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1729aa945f29d91ba541258c8df89027d5792d85a8841fb65e8bf0f4ede4ef61"
 dependencies = [
  "rustls",
+ "tokio",
+]
+
+[[package]]
+name = "tokio-stream"
+version = "0.1.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32da49809aab5c3bc678af03902d4ccddea2a87d028d86392a4b1560c6906c70"
+dependencies = [
+ "futures-core",
+ "pin-project-lite",
  "tokio",
 ]
 
@@ -2618,10 +3241,31 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dbc4bc3a9f746d862c45cb89d705aa10f187bb96c76001afab07a0d35ce60142"
 
 [[package]]
+name = "unicode-bidi"
+version = "0.3.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c1cb5db39152898a79168971543b1cb5020dff7fe43c8dc468b0885f5e29df5"
+
+[[package]]
 name = "unicode-ident"
 version = "1.0.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6e4313cd5fcd3dad5cafa179702e2b244f760991f45397d14d4ebf38247da75"
+
+[[package]]
+name = "unicode-normalization"
+version = "0.1.25"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5fd4f6878c9cb28d874b009da9e8d183b5abc80117c40bbd187a1fde336be6e8"
+dependencies = [
+ "tinyvec",
+]
+
+[[package]]
+name = "unicode-properties"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7df058c713841ad818f1dc5d3fd88063241cc61f49f5fbea4b951e8cf5a8d71d"
 
 [[package]]
 name = "unicode-segmentation"
@@ -2736,6 +3380,12 @@ checksum = "5428f8bf88ea5ddc08faddef2ac4a67e390b88186c703ce6dbd955e1c145aca5"
 dependencies = [
  "wit-bindgen 0.51.0",
 ]
+
+[[package]]
+name = "wasite"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8dad83b4f25e74f184f64c43b150b91efe7647395b42289f38e50566d82855b"
 
 [[package]]
 name = "wasm-bindgen"
@@ -2885,6 +3535,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "whoami"
+version = "1.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d4a4db5077702ca3015d3d02d74974948aba2ad9e12ab7df718ee64ccd7e97d"
+dependencies = [
+ "libredox",
+ "wasite",
+]
+
+[[package]]
 name = "winapi-util"
 version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2930,11 +3590,20 @@ dependencies = [
 
 [[package]]
 name = "windows-sys"
+version = "0.48.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "677d2418bec65e3338edb076e806bc1ec15693c5d0104683f2efe857f61056a9"
+dependencies = [
+ "windows-targets 0.48.5",
+]
+
+[[package]]
+name = "windows-sys"
 version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
 dependencies = [
- "windows-targets",
+ "windows-targets 0.52.6",
 ]
 
 [[package]]
@@ -2948,19 +3617,40 @@ dependencies = [
 
 [[package]]
 name = "windows-targets"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9a2fa6e2155d7247be68c096456083145c183cbbbc2764150dda45a87197940c"
+dependencies = [
+ "windows_aarch64_gnullvm 0.48.5",
+ "windows_aarch64_msvc 0.48.5",
+ "windows_i686_gnu 0.48.5",
+ "windows_i686_msvc 0.48.5",
+ "windows_x86_64_gnu 0.48.5",
+ "windows_x86_64_gnullvm 0.48.5",
+ "windows_x86_64_msvc 0.48.5",
+]
+
+[[package]]
+name = "windows-targets"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b724f72796e036ab90c1021d4780d4d3d648aca59e491e6b98e725b84e99973"
 dependencies = [
- "windows_aarch64_gnullvm",
- "windows_aarch64_msvc",
- "windows_i686_gnu",
+ "windows_aarch64_gnullvm 0.52.6",
+ "windows_aarch64_msvc 0.52.6",
+ "windows_i686_gnu 0.52.6",
  "windows_i686_gnullvm",
- "windows_i686_msvc",
- "windows_x86_64_gnu",
- "windows_x86_64_gnullvm",
- "windows_x86_64_msvc",
+ "windows_i686_msvc 0.52.6",
+ "windows_x86_64_gnu 0.52.6",
+ "windows_x86_64_gnullvm 0.52.6",
+ "windows_x86_64_msvc 0.52.6",
 ]
+
+[[package]]
+name = "windows_aarch64_gnullvm"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2b38e32f0abccf9987a4e3079dfb67dcd799fb61361e53e2882c3cbaf0d905d8"
 
 [[package]]
 name = "windows_aarch64_gnullvm"
@@ -2970,9 +3660,21 @@ checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
 
 [[package]]
 name = "windows_aarch64_msvc"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc35310971f3b2dbbf3f0690a219f40e2d9afcf64f9ab7cc1be722937c26b4bc"
+
+[[package]]
+name = "windows_aarch64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
+
+[[package]]
+name = "windows_i686_gnu"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a75915e7def60c94dcef72200b9a8e58e5091744960da64ec734a6c6e9b3743e"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -2988,9 +3690,21 @@ checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
 
 [[package]]
 name = "windows_i686_msvc"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f55c233f70c4b27f66c523580f78f1004e8b5a8b659e05a4eb49d4166cca406"
+
+[[package]]
+name = "windows_i686_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "53d40abd2583d23e4718fddf1ebec84dbff8381c07cae67ff7768bbf19c6718e"
 
 [[package]]
 name = "windows_x86_64_gnu"
@@ -3000,9 +3714,21 @@ checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b7b52767868a23d5bab768e390dc5f5c55825b6d30b86c844ff2dc7414044cc"
+
+[[package]]
+name = "windows_x86_64_gnullvm"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed94fce61571a4006852b7389a063ab983c02eb1bb37b47f8272ce92d06d9538"
 
 [[package]]
 name = "windows_x86_64_msvc"
@@ -3161,6 +3887,26 @@ dependencies = [
  "quote",
  "syn",
  "synstructure",
+]
+
+[[package]]
+name = "zerocopy"
+version = "0.8.48"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eed437bf9d6692032087e337407a86f04cd8d6a16a37199ed57949d415bd68e9"
+dependencies = [
+ "zerocopy-derive",
+]
+
+[[package]]
+name = "zerocopy-derive"
+version = "0.8.48"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "70e3cd084b1788766f53af483dd21f93881ff30d7320490ec3ef7526d203bad4"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -227,9 +227,9 @@ checksum = "e629a66d692cb9ff1a1c664e41771b3dcaf961985a9774c0eb0bd1b51cf60a48"
 
 [[package]]
 name = "cc"
-version = "1.2.60"
+version = "1.2.62"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "43c5703da9466b66a946814e1adf53ea2c90f10063b86290cc9eb67ce3478a20"
+checksum = "a1dce859f0832a7d088c4f1119888ab94ef4b5d6795d1ce05afb7fe159d79f98"
 dependencies = [
  "find-msvc-tools",
  "shlex",
@@ -810,9 +810,9 @@ checksum = "17e2ac29387b1aa07a1e448f7bb4f35b500787971e965b02842b900afa5c8f6f"
 
 [[package]]
 name = "h2"
-version = "0.4.13"
+version = "0.4.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2f44da3a8150a6703ed5d34e164b875fd14c2cdab9af1252a9a1020bde2bdc54"
+checksum = "171fefbc92fe4a4de27e0698d6a5b392d6a0e333506bc49133760b3bcf948733"
 dependencies = [
  "atomic-waker",
  "bytes",
@@ -840,9 +840,9 @@ dependencies = [
 
 [[package]]
 name = "hashbrown"
-version = "0.17.0"
+version = "0.17.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4f467dd6dccf739c208452f8014c75c18bb8301b050ad1cfb27153803edb0f51"
+checksum = "ed5909b6e89a2db4456e54cd5f673791d7eca6732202bbf2a9cc504fe2f9b84a"
 
 [[package]]
 name = "hashlink"
@@ -1145,9 +1145,9 @@ dependencies = [
 
 [[package]]
 name = "idna_adapter"
-version = "1.2.1"
+version = "1.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3acae9609540aa318d1bc588455225fb2085b9ed0c4f6bd0d9d5bcd86f1a0344"
+checksum = "cb68373c0d6620ef8105e855e7745e18b0d00d3bdb07fb532e434244cdb9a714"
 dependencies = [
  "icu_normalizer",
  "icu_properties",
@@ -1160,7 +1160,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d466e9454f08e4a911e14806c24e16fba1b4c121d1ea474396f396069cf949d9"
 dependencies = [
  "equivalent",
- "hashbrown 0.17.0",
+ "hashbrown 0.17.1",
  "serde",
  "serde_core",
 ]
@@ -1176,16 +1176,6 @@ name = "ipnet"
 version = "2.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d98f6fed1fde3f8c21bc40a1abb88dd75e67924f9cffc3ef95607bad8017f8e2"
-
-[[package]]
-name = "iri-string"
-version = "0.7.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "25e659a4bb38e810ebc252e53b5814ff908a8c58c2a9ce2fae1bbec24cbf4e20"
-dependencies = [
- "memchr",
- "serde",
-]
 
 [[package]]
 name = "itertools"
@@ -1204,9 +1194,9 @@ checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
 
 [[package]]
 name = "js-sys"
-version = "0.3.95"
+version = "0.3.98"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2964e92d1d9dc3364cae4d718d93f227e3abb088e747d92e0395bfdedf1c12ca"
+checksum = "67df7112613f8bfd9150013a0314e196f4800d3201ae742489d999db2f979f08"
 dependencies = [
  "cfg-if",
  "futures-util",
@@ -1376,9 +1366,9 @@ dependencies = [
 
 [[package]]
 name = "libc"
-version = "0.2.185"
+version = "0.2.186"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "52ff2c0fe9bc6cb6b14a0592c2ff4fa9ceb83eea9db979b0487cd054946a2b8f"
+checksum = "68ab91017fe16c622486840e4c83c9a37afeff978bd239b5293d61ece587de66"
 
 [[package]]
 name = "libm"
@@ -1613,15 +1603,14 @@ checksum = "9f7c3e4beb33f85d45ae3e3a1792185706c8e16d043238c593331cc7cd313b50"
 
 [[package]]
 name = "openssl"
-version = "0.10.78"
+version = "0.10.79"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f38c4372413cdaaf3cc79dd92d29d7d9f5ab09b51b10dded508fb90bb70b9222"
+checksum = "bf0b434746ee2832f4f0baf10137e1cabb18cbe6912c69e2e33263c45250f542"
 dependencies = [
  "bitflags",
  "cfg-if",
  "foreign-types",
  "libc",
- "once_cell",
  "openssl-macros",
  "openssl-sys",
 ]
@@ -1645,9 +1634,9 @@ checksum = "7c87def4c32ab89d880effc9e097653c8da5d6ef28e6b539d313baaacfbafcbe"
 
 [[package]]
 name = "openssl-sys"
-version = "0.9.114"
+version = "0.9.115"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "13ce1245cd07fcc4cfdb438f7507b0c7e4f3849a69fd84d52374c66d83741bb6"
+checksum = "158fe5b292746440aa6e7a7e690e55aeb72d41505e2804c23c6973ad0e9c9781"
 dependencies = [
  "cc",
  "libc",
@@ -1719,18 +1708,18 @@ checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
 
 [[package]]
 name = "pin-project"
-version = "1.1.11"
+version = "1.1.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f1749c7ed4bcaf4c3d0a3efc28538844fb29bcdd7d2b67b2be7e20ba861ff517"
+checksum = "2466b2336ed02bcdca6b294417127b90ec92038d1d5c4fbeac971a922e0e0924"
 dependencies = [
  "pin-project-internal",
 ]
 
 [[package]]
 name = "pin-project-internal"
-version = "1.1.11"
+version = "1.1.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d9b20ed30f105399776b9c883e68e536ef602a16ae6f596d2c473591d6ad64c6"
+checksum = "c96395f0a926bc13b1c17622aaddda1ecb55d49c8f1bf9777e4d877800a43f8b"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2149,9 +2138,9 @@ dependencies = [
 
 [[package]]
 name = "rustls"
-version = "0.23.38"
+version = "0.23.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "69f9466fb2c14ea04357e91413efb882e2a6d4a406e625449bc0a5d360d53a21"
+checksum = "ef86cd5876211988985292b91c96a8f2d298df24e75989a43a3c73f2d4d8168b"
 dependencies = [
  "once_cell",
  "rustls-pki-types",
@@ -2162,9 +2151,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-pki-types"
-version = "1.14.0"
+version = "1.14.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "be040f8b0a225e40375822a563fa9524378b9d63112f53e19ffff34df5d33fdd"
+checksum = "30a7197ae7eb376e574fe940d068c30fe0462554a3ddbe4eca7838e049c937a9"
 dependencies = [
  "zeroize",
 ]
@@ -2202,6 +2191,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "scc"
+version = "2.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "46e6f046b7fef48e2660c57ed794263155d713de679057f2d0c169bfc6e756cc"
+dependencies = [
+ "sdd",
+]
+
+[[package]]
 name = "schannel"
 version = "0.1.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2215,6 +2213,12 @@ name = "scopeguard"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
+
+[[package]]
+name = "sdd"
+version = "3.0.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "490dcfcbfef26be6800d11870ff2df8774fa6e86d047e3e8c8a76b25655e41ca"
 
 [[package]]
 name = "security-framework"
@@ -2350,6 +2354,32 @@ dependencies = [
 ]
 
 [[package]]
+name = "serial_test"
+version = "3.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "911bd979bf1070a3f3aa7b691a3b3e9968f339ceeec89e08c280a8a22207a32f"
+dependencies = [
+ "futures-executor",
+ "futures-util",
+ "log",
+ "once_cell",
+ "parking_lot",
+ "scc",
+ "serial_test_derive",
+]
+
+[[package]]
+name = "serial_test_derive"
+version = "3.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0a7d91949b85b0d2fb687445e448b40d322b6b3e4af6b44a29b21d9a5f33e6d9"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "server"
 version = "0.10.1"
 dependencies = [
@@ -2362,6 +2392,7 @@ dependencies = [
  "reqwest",
  "serde",
  "serde_json",
+ "serial_test",
  "sqlx",
  "tempfile",
  "tokio",
@@ -2942,9 +2973,9 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tokio"
-version = "1.52.1"
+version = "1.52.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b67dee974fe86fd92cc45b7a95fdd2f99a36a6d7b0d431a231178d3d670bbcc6"
+checksum = "8fc7f01b389ac15039e4dc9531aa973a135d7a4135281b12d7c1bc79fd57fffe"
 dependencies = [
  "bytes",
  "libc",
@@ -3102,9 +3133,9 @@ dependencies = [
 
 [[package]]
 name = "tower-http"
-version = "0.6.8"
+version = "0.6.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d4e6559d53cc268e5031cd8429d05415bc4cb4aefc4aa5d6cc35fbf5b924a1f8"
+checksum = "68d6fdd9f81c2819c9a8b0e0cd91660e7746a8e6ea2ba7c6b2b057985f6bcb51"
 dependencies = [
  "bitflags",
  "bytes",
@@ -3115,7 +3146,6 @@ dependencies = [
  "http-body-util",
  "http-range-header",
  "httpdate",
- "iri-string",
  "mime",
  "mime_guess",
  "percent-encoding",
@@ -3126,6 +3156,7 @@ dependencies = [
  "tower-layer",
  "tower-service",
  "tracing",
+ "url",
 ]
 
 [[package]]
@@ -3389,9 +3420,9 @@ checksum = "b8dad83b4f25e74f184f64c43b150b91efe7647395b42289f38e50566d82855b"
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.118"
+version = "0.2.121"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0bf938a0bacb0469e83c1e148908bd7d5a6010354cf4fb73279b7447422e3a89"
+checksum = "49ace1d07c165b0864824eee619580c4689389afa9dc9ed3a4c75040d82e6790"
 dependencies = [
  "cfg-if",
  "once_cell",
@@ -3402,9 +3433,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-futures"
-version = "0.4.68"
+version = "0.4.71"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f371d383f2fb139252e0bfac3b81b265689bf45b6874af544ffa4c975ac1ebf8"
+checksum = "96492d0d3ffba25305a7dc88720d250b1401d7edca02cc3bcd50633b424673b8"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -3412,9 +3443,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.118"
+version = "0.2.121"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eeff24f84126c0ec2db7a449f0c2ec963c6a49efe0698c4242929da037ca28ed"
+checksum = "8e68e6f4afd367a562002c05637acb8578ff2dea1943df76afb9e83d177c8578"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -3422,9 +3453,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.118"
+version = "0.2.121"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9d08065faf983b2b80a79fd87d8254c409281cf7de75fc4b773019824196c904"
+checksum = "d95a9ec35c64b2a7cb35d3fead40c4238d0940c86d107136999567a4703259f2"
 dependencies = [
  "bumpalo",
  "proc-macro2",
@@ -3435,9 +3466,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.118"
+version = "0.2.121"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5fd04d9e306f1907bd13c6361b5c6bfc7b3b3c095ed3f8a9246390f8dbdee129"
+checksum = "c4e0100b01e9f0d03189a92b96772a1fb998639d981193d7dbab487302513441"
 dependencies = [
  "unicode-ident",
 ]
@@ -3526,9 +3557,9 @@ dependencies = [
 
 [[package]]
 name = "web-sys"
-version = "0.3.95"
+version = "0.3.98"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4f2dfbb17949fa2088e5d39408c48368947b86f7834484e87b73de55bc14d97d"
+checksum = "4b572dff8bcf38bad0fa19729c89bb5748b2b9b1d8be70cf90df697e3a8f32aa"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -3911,9 +3942,9 @@ dependencies = [
 
 [[package]]
 name = "zerofrom"
-version = "0.1.7"
+version = "0.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "69faa1f2a1ea75661980b013019ed6687ed0e83d069bc1114e2cc74c6c04c4df"
+checksum = "0ec05a11813ea801ff6d75110ad09cd0824ddba17dfe17128ea0d5f68e6c5272"
 dependencies = [
  "zerofrom-derive",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -242,6 +242,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
 
 [[package]]
+name = "cfg_aliases"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
+
+[[package]]
 name = "codee"
 version = "0.3.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -345,32 +351,6 @@ checksum = "589c70f0faf8aa9d17787557d5eae854d7755cac50f5c3d12c81d3d57661cebb"
 dependencies = [
  "convert_case 0.11.0",
 ]
-
-[[package]]
-name = "core-foundation"
-version = "0.9.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "91e195e091a93c46f7102ec7818a2aa394e1e1771c3ab4825963fa03e45afb8f"
-dependencies = [
- "core-foundation-sys",
- "libc",
-]
-
-[[package]]
-name = "core-foundation"
-version = "0.10.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b2a6cd9ae233e7f62ba4e9353e81a88df7fc8a5987b8d445b4d90c879bd156f6"
-dependencies = [
- "core-foundation-sys",
- "libc",
-]
-
-[[package]]
-name = "core-foundation-sys"
-version = "0.8.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
 
 [[package]]
 name = "cpufeatures"
@@ -498,15 +478,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "encoding_rs"
-version = "0.8.35"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "75030f3c4f45dafd7586dd6780965a8c7e8e285a5ecb86713e63a79c5b2766f3"
-dependencies = [
- "cfg-if",
-]
-
-[[package]]
 name = "equivalent"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -584,31 +555,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "fnv"
-version = "1.0.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
-
-[[package]]
 name = "foldhash"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
-
-[[package]]
-name = "foreign-types"
-version = "0.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f6f339eb8adc052cd2ca78910fda869aefa38d22d5cb648e6485e4d3fc06f3b1"
-dependencies = [
- "foreign-types-shared",
-]
-
-[[package]]
-name = "foreign-types-shared"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "00b0228411908ca8685dba7fc2cdd70ec9990a6e753e89b6ac91a84c40fbaf4b"
 
 [[package]]
 name = "form_urlencoded"
@@ -749,8 +699,24 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ff2abc00be7fca6ebc474524697ae276ad847ad0a6b3faa4bcb027e9a4614ad0"
 dependencies = [
  "cfg-if",
+ "js-sys",
  "libc",
  "wasi",
+ "wasm-bindgen",
+]
+
+[[package]]
+name = "getrandom"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "899def5c37c4fd7b2664648c28120ecec138e4d395b459e5ca34f9cce2dd77fd"
+dependencies = [
+ "cfg-if",
+ "js-sys",
+ "libc",
+ "r-efi 5.3.0",
+ "wasip2",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -762,7 +728,7 @@ dependencies = [
  "cfg-if",
  "js-sys",
  "libc",
- "r-efi",
+ "r-efi 6.0.0",
  "wasip2",
  "wasip3",
  "wasm-bindgen",
@@ -807,25 +773,6 @@ name = "guardian"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "17e2ac29387b1aa07a1e448f7bb4f35b500787971e965b02842b900afa5c8f6f"
-
-[[package]]
-name = "h2"
-version = "0.4.14"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "171fefbc92fe4a4de27e0698d6a5b392d6a0e333506bc49133760b3bcf948733"
-dependencies = [
- "atomic-waker",
- "bytes",
- "fnv",
- "futures-core",
- "futures-sink",
- "http",
- "indexmap",
- "slab",
- "tokio",
- "tokio-util",
- "tracing",
-]
 
 [[package]]
 name = "hashbrown"
@@ -976,7 +923,6 @@ dependencies = [
  "bytes",
  "futures-channel",
  "futures-core",
- "h2",
  "http",
  "http-body",
  "httparse",
@@ -1001,22 +947,7 @@ dependencies = [
  "tokio",
  "tokio-rustls",
  "tower-service",
-]
-
-[[package]]
-name = "hyper-tls"
-version = "0.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "70206fc6890eaca9fde8a0bf71caa2ddfc9fe045ac9e5c70df101a7dbde866e0"
-dependencies = [
- "bytes",
- "http-body-util",
- "hyper",
- "hyper-util",
- "native-tls",
- "tokio",
- "tokio-native-tls",
- "tower-service",
+ "webpki-roots",
 ]
 
 [[package]]
@@ -1037,11 +968,9 @@ dependencies = [
  "percent-encoding",
  "pin-project-lite",
  "socket2",
- "system-configuration",
  "tokio",
  "tower-service",
  "tracing",
- "windows-registry",
 ]
 
 [[package]]
@@ -1427,6 +1356,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
 
 [[package]]
+name = "lru-slab"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "112b39cec0b298b6c1999fee3e31427f74f676e4cb9879ed1a121b43661a4154"
+
+[[package]]
 name = "manyhow"
 version = "0.11.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1508,23 +1443,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "native-tls"
-version = "0.2.18"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "465500e14ea162429d264d44189adc38b199b62b1c21eea9f69e4b73cb03bbf2"
-dependencies = [
- "libc",
- "log",
- "openssl",
- "openssl-probe",
- "openssl-sys",
- "schannel",
- "security-framework",
- "security-framework-sys",
- "tempfile",
-]
-
-[[package]]
 name = "next_tuple"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1550,7 +1468,7 @@ dependencies = [
  "num-integer",
  "num-iter",
  "num-traits",
- "rand",
+ "rand 0.8.6",
  "smallvec",
  "zeroize",
 ]
@@ -1600,49 +1518,6 @@ name = "once_cell"
 version = "1.21.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9f7c3e4beb33f85d45ae3e3a1792185706c8e16d043238c593331cc7cd313b50"
-
-[[package]]
-name = "openssl"
-version = "0.10.79"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bf0b434746ee2832f4f0baf10137e1cabb18cbe6912c69e2e33263c45250f542"
-dependencies = [
- "bitflags",
- "cfg-if",
- "foreign-types",
- "libc",
- "openssl-macros",
- "openssl-sys",
-]
-
-[[package]]
-name = "openssl-macros"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a948666b637a0f465e8564c73e89d4dde00d72d4d473cc972f390fc3dcee7d9c"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
-]
-
-[[package]]
-name = "openssl-probe"
-version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7c87def4c32ab89d880effc9e097653c8da5d6ef28e6b539d313baaacfbafcbe"
-
-[[package]]
-name = "openssl-sys"
-version = "0.9.115"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "158fe5b292746440aa6e7a7e690e55aeb72d41505e2804c23c6973ad0e9c9781"
-dependencies = [
- "cc",
- "libc",
- "pkg-config",
- "vcpkg",
-]
 
 [[package]]
 name = "or_poisoned"
@@ -1849,6 +1724,61 @@ dependencies = [
 ]
 
 [[package]]
+name = "quinn"
+version = "0.11.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9e20a958963c291dc322d98411f541009df2ced7b5a4f2bd52337638cfccf20"
+dependencies = [
+ "bytes",
+ "cfg_aliases",
+ "pin-project-lite",
+ "quinn-proto",
+ "quinn-udp",
+ "rustc-hash",
+ "rustls",
+ "socket2",
+ "thiserror 2.0.18",
+ "tokio",
+ "tracing",
+ "web-time",
+]
+
+[[package]]
+name = "quinn-proto"
+version = "0.11.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "434b42fec591c96ef50e21e886936e66d3cc3f737104fdb9b737c40ffb94c098"
+dependencies = [
+ "bytes",
+ "getrandom 0.3.4",
+ "lru-slab",
+ "rand 0.9.4",
+ "ring",
+ "rustc-hash",
+ "rustls",
+ "rustls-pki-types",
+ "slab",
+ "thiserror 2.0.18",
+ "tinyvec",
+ "tracing",
+ "web-time",
+]
+
+[[package]]
+name = "quinn-udp"
+version = "0.5.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "addec6a0dcad8a8d96a771f815f0eaf55f9d1805756410b39f5fa81332574cbd"
+dependencies = [
+ "cfg_aliases",
+ "libc",
+ "once_cell",
+ "socket2",
+ "tracing",
+ "windows-sys 0.52.0",
+]
+
+[[package]]
 name = "quote"
 version = "1.0.45"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1881,6 +1811,12 @@ dependencies = [
 
 [[package]]
 name = "r-efi"
+version = "5.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
+
+[[package]]
+name = "r-efi"
 version = "6.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
@@ -1892,8 +1828,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5ca0ecfa931c29007047d1bc58e623ab12e5590e8c7cc53200d5202b69266d8a"
 dependencies = [
  "libc",
- "rand_chacha",
- "rand_core",
+ "rand_chacha 0.3.1",
+ "rand_core 0.6.4",
+]
+
+[[package]]
+name = "rand"
+version = "0.9.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "44c5af06bb1b7d3216d91932aed5265164bf384dc89cd6ba05cf59a35f5f76ea"
+dependencies = [
+ "rand_chacha 0.9.0",
+ "rand_core 0.9.5",
 ]
 
 [[package]]
@@ -1903,7 +1849,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88"
 dependencies = [
  "ppv-lite86",
- "rand_core",
+ "rand_core 0.6.4",
+]
+
+[[package]]
+name = "rand_chacha"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3022b5f1df60f26e1ffddd6c66e8aa15de382ae63b3a0c1bfc0e4d3e3f325cb"
+dependencies = [
+ "ppv-lite86",
+ "rand_core 0.9.5",
 ]
 
 [[package]]
@@ -1913,6 +1869,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
 dependencies = [
  "getrandom 0.2.17",
+]
+
+[[package]]
+name = "rand_core"
+version = "0.9.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "76afc826de14238e6e8c374ddcc1fa19e374fd8dd986b0d2af0d02377261d83c"
+dependencies = [
+ "getrandom 0.3.4",
 ]
 
 [[package]]
@@ -2024,30 +1989,27 @@ checksum = "eddd3ca559203180a307f12d114c268abf583f59b03cb906fd0b3ff8646c1147"
 dependencies = [
  "base64",
  "bytes",
- "encoding_rs",
  "futures-core",
  "futures-util",
- "h2",
  "http",
  "http-body",
  "http-body-util",
  "hyper",
  "hyper-rustls",
- "hyper-tls",
  "hyper-util",
  "js-sys",
  "log",
- "mime",
- "native-tls",
  "percent-encoding",
  "pin-project-lite",
+ "quinn",
+ "rustls",
  "rustls-pki-types",
  "serde",
  "serde_json",
  "serde_urlencoded",
  "sync_wrapper",
  "tokio",
- "tokio-native-tls",
+ "tokio-rustls",
  "tokio-util",
  "tower",
  "tower-http",
@@ -2057,6 +2019,7 @@ dependencies = [
  "wasm-bindgen-futures",
  "wasm-streams 0.4.2",
  "web-sys",
+ "webpki-roots",
 ]
 
 [[package]]
@@ -2086,7 +2049,7 @@ dependencies = [
  "num-traits",
  "pkcs1",
  "pkcs8",
- "rand_core",
+ "rand_core 0.6.4",
  "signature",
  "spki",
  "subtle",
@@ -2143,6 +2106,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ef86cd5876211988985292b91c96a8f2d298df24e75989a43a3c73f2d4d8168b"
 dependencies = [
  "once_cell",
+ "ring",
  "rustls-pki-types",
  "rustls-webpki",
  "subtle",
@@ -2155,6 +2119,7 @@ version = "1.14.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "30a7197ae7eb376e574fe940d068c30fe0462554a3ddbe4eca7838e049c937a9"
 dependencies = [
+ "web-time",
  "zeroize",
 ]
 
@@ -2200,15 +2165,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "schannel"
-version = "0.1.29"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "91c1b7e4904c873ef0710c1f407dde2e6287de2bebc1bbbf7d430bb7cbffd939"
-dependencies = [
- "windows-sys 0.61.2",
-]
-
-[[package]]
 name = "scopeguard"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2219,29 +2175,6 @@ name = "sdd"
 version = "3.0.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "490dcfcbfef26be6800d11870ff2df8774fa6e86d047e3e8c8a76b25655e41ca"
-
-[[package]]
-name = "security-framework"
-version = "3.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b7f4bc775c73d9a02cde8bf7b2ec4c9d12743edf609006c7facc23998404cd1d"
-dependencies = [
- "bitflags",
- "core-foundation 0.10.1",
- "core-foundation-sys",
- "libc",
- "security-framework-sys",
-]
-
-[[package]]
-name = "security-framework-sys"
-version = "2.17.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6ce2691df843ecc5d231c0b14ece2acc3efb62c0a398c7e1d875f3983ce020e3"
-dependencies = [
- "core-foundation-sys",
- "libc",
-]
 
 [[package]]
 name = "semver"
@@ -2515,7 +2448,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "77549399552de45a898a580c1b41d445bf730df867cc44e6c0233bbc4b8329de"
 dependencies = [
  "digest",
- "rand_core",
+ "rand_core 0.6.4",
 ]
 
 [[package]]
@@ -2683,7 +2616,7 @@ dependencies = [
  "memchr",
  "once_cell",
  "percent-encoding",
- "rand",
+ "rand 0.8.6",
  "rsa",
  "sha1",
  "sha2",
@@ -2720,7 +2653,7 @@ dependencies = [
  "md-5",
  "memchr",
  "once_cell",
- "rand",
+ "rand 0.8.6",
  "serde",
  "serde_json",
  "sha2",
@@ -2820,27 +2753,6 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
-]
-
-[[package]]
-name = "system-configuration"
-version = "0.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a13f3d0daba03132c0aa9767f98351b3488edc2c100cda2d2ec2b04f3d8d3c8b"
-dependencies = [
- "bitflags",
- "core-foundation 0.9.4",
- "system-configuration-sys",
-]
-
-[[package]]
-name = "system-configuration-sys"
-version = "0.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e1d1b10ced5ca923a1fcb8d03e96b8d3268065d724548c0211415ff6ac6bac4"
-dependencies = [
- "core-foundation-sys",
- "libc",
 ]
 
 [[package]]
@@ -2997,16 +2909,6 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
-]
-
-[[package]]
-name = "tokio-native-tls"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bbae76ab933c85776efabc971569dd6119c580d8f5d448769dec1764bf796ef2"
-dependencies = [
- "native-tls",
- "tokio",
 ]
 
 [[package]]
@@ -3566,6 +3468,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "web-time"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a6580f308b1fad9207618087a65c04e7a10bc77e02c8e84e9b00dd4b12fa0bb"
+dependencies = [
+ "js-sys",
+ "wasm-bindgen",
+]
+
+[[package]]
+name = "webpki-roots"
+version = "1.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "52f5ee44c96cf55f1b349600768e3ece3a8f26010c05265ab73f945bb1a2eb9d"
+dependencies = [
+ "rustls-pki-types",
+]
+
+[[package]]
 name = "whoami"
 version = "1.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3589,35 +3510,6 @@ name = "windows-link"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
-
-[[package]]
-name = "windows-registry"
-version = "0.6.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "02752bf7fbdcce7f2a27a742f798510f3e5ad88dbe84871e5168e2120c3d5720"
-dependencies = [
- "windows-link",
- "windows-result",
- "windows-strings",
-]
-
-[[package]]
-name = "windows-result"
-version = "0.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7781fa89eaf60850ac3d2da7af8e5242a5ea78d1a11c49bf2910bb5a73853eb5"
-dependencies = [
- "windows-link",
-]
-
-[[package]]
-name = "windows-strings"
-version = "0.5.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7837d08f69c77cf6b07689544538e017c1bfcf57e34b4c0ff58e6c2cd3b37091"
-dependencies = [
- "windows-link",
-]
 
 [[package]]
 name = "windows-sys"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ serde = { version = "1.0.228", features = ["derive"] }
 serde_json = "1.0.149"
 tracing = "0.1.44"
 tracing-subscriber = { version = "0.3.23", features = ["env-filter"] }
-reqwest = { version = "0.12.28", features = ["json", "stream"] }
+reqwest = { version = "0.12.28", default-features = false, features = ["rustls-tls", "json", "stream"] }
 tower-http = { version = "0.6.10", features = ["cors", "fs", "trace"] }
 leptos = { version = "0.8.19", features = ["csr"] }
 wasm-bindgen = "0.2.121"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,3 +17,4 @@ tower = "0.5"
 http-body-util = "0.1"
 async-trait = "0.1"
 futures-util = "0.3"
+sqlx = { version = "0.8", default-features = false, features = ["runtime-tokio", "sqlite", "migrate", "macros"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,18 +3,18 @@ members = ["server", "frontend"]
 resolver = "2"
 
 [workspace.dependencies]
-axum = "0.8"
-tokio = { version = "1", features = ["full"] }
-serde = { version = "1", features = ["derive"] }
-serde_json = "1"
-tracing = "0.1"
-tracing-subscriber = { version = "0.3", features = ["env-filter"] }
-reqwest = { version = "0.12", features = ["json", "stream"] }
-tower-http = { version = "0.6", features = ["cors", "fs", "trace"] }
-leptos = { version = "0.8", features = ["csr"] }
-wasm-bindgen = "0.2"
-tower = "0.5"
-http-body-util = "0.1"
-async-trait = "0.1"
-futures-util = "0.3"
-sqlx = { version = "0.8", default-features = false, features = ["runtime-tokio", "sqlite", "migrate", "macros"] }
+axum = "0.8.9"
+tokio = { version = "1.52.3", features = ["full"] }
+serde = { version = "1.0.228", features = ["derive"] }
+serde_json = "1.0.149"
+tracing = "0.1.44"
+tracing-subscriber = { version = "0.3.23", features = ["env-filter"] }
+reqwest = { version = "0.12.28", features = ["json", "stream"] }
+tower-http = { version = "0.6.10", features = ["cors", "fs", "trace"] }
+leptos = { version = "0.8.19", features = ["csr"] }
+wasm-bindgen = "0.2.121"
+tower = "0.5.3"
+http-body-util = "0.1.3"
+async-trait = "0.1.89"
+futures-util = "0.3.32"
+sqlx = { version = "0.8.6", default-features = false, features = ["runtime-tokio", "sqlite", "migrate", "macros"] }

--- a/docs/sqlite-persistence.md
+++ b/docs/sqlite-persistence.md
@@ -1,0 +1,174 @@
+# SQLite Persistence Foundation
+
+**Issue:** [#27](https://github.com/BhavsarDevansh/librechat/issues/27)  
+**Status:** Implemented  
+**Scope:** Backend (`server` crate)
+
+---
+
+## Architecture & Design
+
+### Goal
+Introduce a lightweight, local-first persistence layer for LibreChat using
+SQLite and SQLx.  This is the **foundation** for Phase 2; later issues will
+add repository functions, chat-history APIs, and UI integration.
+
+### Data Flow
+
+```
+┌─────────────┐     ┌──────────────┐     ┌────────────────┐
+│   Binary    │────>│  AppState    │────>│  SqlitePool    │
+│  (main.rs)  │     │  (state.rs)  │     │ (database.rs)  │
+└─────────────┘     └──────────────┘     └────────────────┘
+                                                    │
+                                                    ▼
+                                           ┌────────────────┐
+                                           │  migrations/   │
+                                           │  (embedded)    │
+                                           └────────────────┘
+```
+
+1. On startup `main.rs` calls `AppState::init().await`.
+2. `AppState::init()` resolves the database URL, creates a [`SqlitePool`], and
+   runs pending migrations via [`sqlx::migrate!`].
+3. The pool is stored in `AppState.db_pool` as `Option<SqlitePool>`.
+4. Route handlers receive `AppState` via Axum's `State` extractor and can
+   use `state.db_pool` when persistence logic is added in future issues.
+
+### Design Decisions
+
+| Decision | Rationale |
+|----------|-----------|
+| **SQLite (not PostgreSQL / MySQL)** | Targets Raspberry Pi and legacy hardware; zero external daemon, minimal binary overhead, single-file portability. |
+| **SQLx (not Diesel / sea-orm)** | Async-first, compile-time query checking, lightweight, and already fits the Tokio / Axum stack. |
+| **Optional pool in `AppState`** | Existing integration tests construct `AppState` directly and must continue to compile without a database.  The binary path always initialises the pool; test paths leave it `None`. |
+| **Migrations embedded at compile time** | `sqlx::migrate!("./migrations")` means migrations ship with the binary; no external migration runner is needed. |
+| **Single-row tables for settings** | `user_settings` and `model_preferences` use `PRIMARY KEY CHECK (id = 1)` so there is exactly one global configuration row, avoiding multi-user complexity that is out of scope for this issue. |
+
+---
+
+## API Reference
+
+### `server::database`
+
+```rust
+pub const DEFAULT_DATABASE_URL: &str = "sqlite:librechat.db";
+pub const DATABASE_URL_ENV: &str = "LIBRECHAT_DATABASE_URL";
+
+pub fn default_database_url() -> String;
+pub async fn init_pool(database_url: &str) -> Result<SqlitePool, sqlx::Error>;
+pub async fn run_migrations(pool: &SqlitePool) -> Result<(), sqlx::migrate::MigrateError>;
+pub async fn table_exists(pool: &SqlitePool, table_name: &str) -> Result<bool, sqlx::Error>;
+```
+
+#### `default_database_url`
+Reads `LIBRECHAT_DATABASE_URL`; falls back to `sqlite:librechat.db`.
+
+#### `init_pool`
+Builds a [`SqlitePool`] with `create_if_missing(true)` so the database file
+is created automatically when it does not yet exist.
+
+#### `run_migrations`
+Executes all `.sql` files in `server/migrations/` in lexicographic order.
+Migration state is tracked in a `_sqlx_migrations` table managed by SQLx.
+
+#### `table_exists`
+Compile-time checked query (`sqlx::query!`) returning `true` when the
+named table is present in `sqlite_master`.
+
+### `server::state::AppState`
+
+```rust
+pub struct AppState {
+    pub provider: Arc<dyn LlmProvider>,
+    pub static_dir: PathBuf,
+    pub db_pool: Option<SqlitePool>,
+}
+
+impl AppState {
+    pub fn new() -> Self;                       // no database
+    pub fn with_static_dir(PathBuf) -> Self;  // no database
+    pub async fn init() -> Result<Self, DatabaseInitError>;
+}
+```
+
+`AppState::init()` is the **production** constructor.  It:
+1. Resolves the default database URL.
+2. Creates the pool.
+3. Runs migrations.
+4. Returns an `AppState` with `db_pool: Some(...)`.
+
+If any step fails, a [`DatabaseInitError`] is returned with a clear message so
+that the binary can log the problem and exit cleanly.
+
+---
+
+## Configuration
+
+| Environment Variable | Default | Description |
+|----------------------|---------|-------------|
+| `LIBRECHAT_DATABASE_URL` | `sqlite:librechat.db` | SQLite connection URL.  Absolute paths are supported (`sqlite:/var/lib/librechat.db`). |
+
+No additional environment variables or feature flags are introduced.
+
+---
+
+## Testing Guide
+
+### Running the database tests
+
+```bash
+cargo test -p server --test database_persistence
+```
+
+Tests are deterministic and use **temporary SQLite files** via `tempfile`;
+no real provider credentials or external network calls are required.
+
+### Test coverage
+
+| Test | What it validates |
+|------|-------------------|
+| `test_database_pool_initialization` | Pool can be created and queried. |
+| `test_migrations_run_on_startup` | Migrations execute without error. |
+| `test_database_url_env_var_override` | `LIBRECHAT_DATABASE_URL` overrides the default. |
+| `test_migrated_table_exists` | A migrated table (`conversations`) is present after startup, verified with a compile-time checked query. |
+
+### Extending the test suite
+
+When adding new repository functions:
+1. Create a temporary database with `tempfile::tempdir()`.
+2. Call `database::init_pool(&url).await`.
+3. Call `database::run_migrations(&pool).await`.
+4. Exercise the new function and assert on returned data.
+
+### Offline compilation (CI / fresh checkout)
+
+Compile-time checked queries require schema metadata at build time.  To
+enable building without a live database:
+
+```bash
+# 1. Ensure migrations are applied to a local database.
+export DATABASE_URL="sqlite:librechat.db"
+cargo run -p server   # or sqlx migrate run
+
+# 2. Generate offline query metadata.
+cargo sqlx prepare --workspace
+
+# 3. Check in the generated .sqlx/ directory.
+git add .sqlx/
+```
+
+The `.sqlx/` directory is already committed for this issue; future PRs that
+add `query!` / `query_as!` calls must re-run `cargo sqlx prepare` and include
+the updated metadata.
+
+---
+
+## Migration / Upgrade Notes
+
+- **No breaking changes** to existing HTTP routes or `AppState` constructors
+  used by tests (`new()`, `with_static_dir()`, `with_provider_and_static_dir()`).
+- **New field** `db_pool: Option<SqlitePool>` added to `AppState`.  Code that
+  constructs `AppState` with a struct literal must add `db_pool: None`.
+- The binary entry point (`main.rs`) now calls `AppState::init().await` and
+  exits with a clear error if the database cannot be initialised.

--- a/docs/sqlite-persistence.md
+++ b/docs/sqlite-persistence.md
@@ -9,6 +9,7 @@
 ## Architecture & Design
 
 ### Goal
+
 Introduce a lightweight, local-first persistence layer for LibreChat using
 SQLite and SQLx.  This is the **foundation** for Phase 2; later issues will
 add repository functions, chat-history APIs, and UI integration.
@@ -62,17 +63,21 @@ pub async fn table_exists(pool: &SqlitePool, table_name: &str) -> Result<bool, s
 ```
 
 #### `default_database_url`
+
 Reads `LIBRECHAT_DATABASE_URL`; falls back to `sqlite:librechat.db`.
 
 #### `init_pool`
+
 Builds a [`SqlitePool`] with `create_if_missing(true)` so the database file
 is created automatically when it does not yet exist.
 
 #### `run_migrations`
+
 Executes all `.sql` files in `server/migrations/` in lexicographic order.
 Migration state is tracked in a `_sqlx_migrations` table managed by SQLx.
 
 #### `table_exists`
+
 Compile-time checked query (`sqlx::query!`) returning `true` when the
 named table is present in `sqlite_master`.
 

--- a/docs/sqlite-persistence.md
+++ b/docs/sqlite-persistence.md
@@ -15,7 +15,7 @@ add repository functions, chat-history APIs, and UI integration.
 
 ### Data Flow
 
-```
+```text
 ┌─────────────┐     ┌──────────────┐     ┌────────────────┐
 │   Binary    │────>│  AppState    │────>│  SqlitePool    │
 │  (main.rs)  │     │  (state.rs)  │     │ (database.rs)  │

--- a/server/Cargo.toml
+++ b/server/Cargo.toml
@@ -17,6 +17,7 @@ reqwest = { workspace = true, features = ["json", "stream"] }
 tower-http = { workspace = true }
 async-trait = { workspace = true }
 futures-util = { workspace = true }
+sqlx = { workspace = true }
 
 [dev-dependencies]
 tower = { workspace = true }

--- a/server/Cargo.toml
+++ b/server/Cargo.toml
@@ -22,7 +22,8 @@ sqlx = { workspace = true }
 [dev-dependencies]
 tower = { workspace = true }
 http-body-util = { workspace = true }
-http = "1"
-toml = "0.8"
-regex = "1"
-tempfile = "3"
+http = "1.4.0"
+toml = "0.8.23"
+regex = "1.12.3"
+tempfile = "3.27.0"
+serial_test = "3.2.0"

--- a/server/migrations/1_initial_schema.sql
+++ b/server/migrations/1_initial_schema.sql
@@ -48,5 +48,6 @@ CREATE TRIGGER IF NOT EXISTS update_conversations_timestamp
     AFTER UPDATE ON conversations
     FOR EACH ROW
 BEGIN
-    UPDATE conversations SET updated_at = CURRENT_TIMESTAMP WHERE id = NEW.id;
+    UPDATE conversations SET updated_at = CURRENT_TIMESTAMP
+    WHERE id = NEW.id;
 END;

--- a/server/migrations/1_initial_schema.sql
+++ b/server/migrations/1_initial_schema.sql
@@ -39,3 +39,14 @@ CREATE TABLE IF NOT EXISTS model_preferences (
     temperature REAL,
     max_tokens INTEGER
 );
+
+-- Index for efficient message lookups by conversation
+CREATE INDEX IF NOT EXISTS idx_messages_conversation_id ON messages(conversation_id);
+
+-- Trigger to auto-update updated_at on conversation changes
+CREATE TRIGGER IF NOT EXISTS update_conversations_timestamp
+    AFTER UPDATE ON conversations
+    FOR EACH ROW
+BEGIN
+    UPDATE conversations SET updated_at = CURRENT_TIMESTAMP WHERE id = NEW.id;
+END;

--- a/server/migrations/1_initial_schema.sql
+++ b/server/migrations/1_initial_schema.sql
@@ -1,0 +1,41 @@
+-- Initial schema for LibreChat persistence layer (Phase 2).
+--
+-- Tables:
+--   conversations    – chat threads
+--   messages       – individual messages within a conversation
+--   user_settings  – global user preferences (single-row table)
+--   model_preferences – selected provider / model configuration (single-row table)
+
+-- Chat threads
+CREATE TABLE IF NOT EXISTS conversations (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    title TEXT,
+    created_at DATETIME DEFAULT CURRENT_TIMESTAMP,
+    updated_at DATETIME DEFAULT CURRENT_TIMESTAMP
+);
+
+-- Messages belonging to a conversation
+CREATE TABLE IF NOT EXISTS messages (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    conversation_id INTEGER NOT NULL,
+    role TEXT NOT NULL,
+    content TEXT NOT NULL,
+    created_at DATETIME DEFAULT CURRENT_TIMESTAMP,
+    FOREIGN KEY (conversation_id) REFERENCES conversations(id) ON DELETE CASCADE
+);
+
+-- Global user settings (single row, id is pinned to 1)
+CREATE TABLE IF NOT EXISTS user_settings (
+    id INTEGER PRIMARY KEY CHECK (id = 1),
+    theme TEXT DEFAULT 'system',
+    language TEXT DEFAULT 'en'
+);
+
+-- Model / provider preferences (single row, id is pinned to 1)
+CREATE TABLE IF NOT EXISTS model_preferences (
+    id INTEGER PRIMARY KEY CHECK (id = 1),
+    provider TEXT,
+    model TEXT,
+    temperature REAL,
+    max_tokens INTEGER
+);

--- a/server/migrations/1_initial_schema.sql
+++ b/server/migrations/1_initial_schema.sql
@@ -8,7 +8,7 @@
 
 -- Chat threads
 CREATE TABLE IF NOT EXISTS conversations (
-    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    id INTEGER PRIMARY KEY,
     title TEXT,
     created_at DATETIME DEFAULT CURRENT_TIMESTAMP,
     updated_at DATETIME DEFAULT CURRENT_TIMESTAMP
@@ -16,7 +16,7 @@ CREATE TABLE IF NOT EXISTS conversations (
 
 -- Messages belonging to a conversation
 CREATE TABLE IF NOT EXISTS messages (
-    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    id INTEGER PRIMARY KEY,
     conversation_id INTEGER NOT NULL,
     role TEXT NOT NULL,
     content TEXT NOT NULL,
@@ -44,9 +44,11 @@ CREATE TABLE IF NOT EXISTS model_preferences (
 CREATE INDEX IF NOT EXISTS idx_messages_conversation_id ON messages(conversation_id);
 
 -- Trigger to auto-update updated_at on conversation changes
+-- Trigger to auto-update updated_at on conversation changes
 CREATE TRIGGER IF NOT EXISTS update_conversations_timestamp
     AFTER UPDATE ON conversations
     FOR EACH ROW
+    WHEN OLD.updated_at IS NEW.updated_at
 BEGIN
     UPDATE conversations SET updated_at = CURRENT_TIMESTAMP
     WHERE id = NEW.id;

--- a/server/src/database.rs
+++ b/server/src/database.rs
@@ -40,8 +40,32 @@ pub fn default_database_url() -> String {
 /// The pool is cheap to clone and intended to be stored in [`AppState`].
 /// The database file is created automatically if it does not already exist.
 pub async fn init_pool(database_url: &str) -> Result<SqlitePool, sqlx::Error> {
+    let max_connections: u32 = std::env::var("LIBRECHAT_DB_MAX_CONNECTIONS")
+        .ok()
+        .and_then(|v| v.parse().ok())
+        .unwrap_or(5);
+    let connect_timeout_secs: u64 = std::env::var("LIBRECHAT_DB_CONNECT_TIMEOUT")
+        .ok()
+        .and_then(|v| v.parse().ok())
+        .unwrap_or(10);
+    let idle_timeout_secs: u64 = std::env::var("LIBRECHAT_DB_IDLE_TIMEOUT")
+        .ok()
+        .and_then(|v| v.parse().ok())
+        .unwrap_or(600);
+    let max_lifetime_secs: u64 = std::env::var("LIBRECHAT_DB_MAX_LIFETIME")
+        .ok()
+        .and_then(|v| v.parse().ok())
+        .unwrap_or(1800);
+
     let opts = SqliteConnectOptions::from_str(database_url)?.create_if_missing(true);
-    SqlitePoolOptions::new().connect_with(opts).await
+
+    SqlitePoolOptions::new()
+        .max_connections(max_connections)
+        .acquire_timeout(std::time::Duration::from_secs(connect_timeout_secs))
+        .idle_timeout(Some(std::time::Duration::from_secs(idle_timeout_secs)))
+        .max_lifetime(Some(std::time::Duration::from_secs(max_lifetime_secs)))
+        .connect_with(opts)
+        .await
 }
 
 /// Run embedded SQLx migrations against the provided pool.

--- a/server/src/database.rs
+++ b/server/src/database.rs
@@ -1,0 +1,68 @@
+//! SQLite persistence layer for the LibreChat server.
+//!
+//! Provides pool creation, migration execution, and helpers for the
+//! default database URL.  The module is intentionally small so that later
+//! issues can introduce repository functions rather than issuing ad-hoc SQL
+//! from route handlers.
+//!
+//! # Compile-time checked queries
+//!
+//! The module demonstrates SQLx compile-time checked queries via
+//! [`sqlx::query!`].  To build without a live database connection, run
+//! `cargo sqlx prepare --workspace` after ensuring migrations are applied to
+//! a local database and `DATABASE_URL` is exported.  The generated `.sqlx/`
+//! directory is checked into version control so that CI and fresh checkouts
+//! can compile offline.
+
+use sqlx::sqlite::{SqliteConnectOptions, SqlitePool, SqlitePoolOptions};
+use std::str::FromStr;
+
+/// Default SQLite database URL used when `LIBRECHAT_DATABASE_URL` is unset.
+///
+/// Points to `librechat.db` in the process's current working directory,
+/// which is suitable for local development.
+pub const DEFAULT_DATABASE_URL: &str = "sqlite:librechat.db";
+
+/// Environment variable key for overriding the database URL.
+pub const DATABASE_URL_ENV: &str = "LIBRECHAT_DATABASE_URL";
+
+/// Resolve the database URL.
+///
+/// Checks `LIBRECHAT_DATABASE_URL` first; if unset, falls back to
+/// [`DEFAULT_DATABASE_URL`].
+#[must_use]
+pub fn default_database_url() -> String {
+    std::env::var(DATABASE_URL_ENV).unwrap_or_else(|_| DEFAULT_DATABASE_URL.to_string())
+}
+
+/// Create a new SQLite connection pool.
+///
+/// The pool is cheap to clone and intended to be stored in [`AppState`].
+/// The database file is created automatically if it does not already exist.
+pub async fn init_pool(database_url: &str) -> Result<SqlitePool, sqlx::Error> {
+    let opts = SqliteConnectOptions::from_str(database_url)?.create_if_missing(true);
+    SqlitePoolOptions::new().connect_with(opts).await
+}
+
+/// Run embedded SQLx migrations against the provided pool.
+///
+/// Migrations live in `server/migrations/` and are embedded at compile time
+/// via [`sqlx::migrate!`].
+pub async fn run_migrations(pool: &SqlitePool) -> Result<(), sqlx::migrate::MigrateError> {
+    sqlx::migrate!("./migrations").run(pool).await
+}
+
+/// Verify that a named table exists in the SQLite schema.
+///
+/// This is a **compile-time checked** query — the SQL is validated against
+/// the database schema at build time.  See the module-level docs for the
+/// offline-prepare workflow.
+pub async fn table_exists(pool: &SqlitePool, table_name: &str) -> Result<bool, sqlx::Error> {
+    let row = sqlx::query!(
+        "SELECT COUNT(*) as count FROM sqlite_master WHERE type = 'table' AND name = ?1",
+        table_name
+    )
+    .fetch_one(pool)
+    .await?;
+    Ok(row.count > 0)
+}

--- a/server/src/database.rs
+++ b/server/src/database.rs
@@ -57,7 +57,7 @@ pub async fn init_pool(database_url: &str) -> Result<SqlitePool, sqlx::Error> {
         .and_then(|v| v.parse().ok())
         .unwrap_or(1800);
 
-    let opts = SqliteConnectOptions::from_str(database_url)?.create_if_missing(true);
+    let opts = SqliteConnectOptions::from_str(database_url)?.create_if_missing(true).foreign_keys(true);
 
     SqlitePoolOptions::new()
         .max_connections(max_connections)

--- a/server/src/lib.rs
+++ b/server/src/lib.rs
@@ -1,9 +1,10 @@
 //! LibreChat server library.
 //!
 //! Exposes the [`app`] constructor, [`AppState`], [`resolve_port`], and the
-//! [`providers`] module for use by the binary entry point and integration
-//! tests alike.
+//! [`providers`] and [`database`] modules for use by the binary entry point
+//! and integration tests alike.
 
+pub mod database;
 pub mod providers;
 pub mod state;
 

--- a/server/src/main.rs
+++ b/server/src/main.rs
@@ -24,10 +24,18 @@ async fn main() {
 
     tracing::info!("Listening on {addr}");
 
-    let state = AppState::init().await.unwrap_or_else(|e| {
-        tracing::error!("Database initialisation failed: {e}");
-        std::process::exit(1);
-    });
+    let init_timeout = std::time::Duration::from_secs(30);
+    let state = match tokio::time::timeout(init_timeout, AppState::init()).await {
+        Ok(Ok(state)) => state,
+        Ok(Err(e)) => {
+            tracing::error!("Database initialisation failed: {e}");
+            std::process::exit(1);
+        }
+        Err(_) => {
+            tracing::error!("Database initialisation timed out after {init_timeout:?}");
+            std::process::exit(1);
+        }
+    };
 
     axum::serve(listener, app(state))
         .await

--- a/server/src/main.rs
+++ b/server/src/main.rs
@@ -1,7 +1,8 @@
 //! LibreChat server binary — starts the Axum HTTP server.
 //!
 //! Configures structured logging via `tracing-subscriber`, resolves the listen
-//! port from `LIBRECHAT_PORT` (default `3000`), and serves the application.
+//! port from `LIBRECHAT_PORT` (default `3000`), initialises the SQLite
+//! persistence layer, and serves the application.
 
 use server::{app, resolve_port, state::AppState};
 use tracing_subscriber::EnvFilter;
@@ -23,7 +24,12 @@ async fn main() {
 
     tracing::info!("Listening on {addr}");
 
-    axum::serve(listener, app(AppState::new()))
+    let state = AppState::init().await.unwrap_or_else(|e| {
+        tracing::error!("Database initialisation failed: {e}");
+        std::process::exit(1);
+    });
+
+    axum::serve(listener, app(state))
         .await
         .expect("server error");
 }

--- a/server/src/state.rs
+++ b/server/src/state.rs
@@ -1,10 +1,12 @@
 //! Shared application state for the Axum server.
 
+use crate::database::{default_database_url, init_pool, run_migrations};
 use crate::providers::{
     ChatCompletionChunk, ChatCompletionRequest, ChatCompletionResponse, LlmProvider, ModelInfo,
     OpenAiProvider, ProviderError,
 };
 use async_trait::async_trait;
+use sqlx::sqlite::SqlitePool;
 use std::path::PathBuf;
 use std::sync::Arc;
 use tokio::sync::mpsc;
@@ -19,22 +21,16 @@ const STATIC_DIR_ENV: &str = "LIBRECHAT_STATIC_DIR";
 /// Application state shared across all request handlers via Axum's
 /// [`State`](axum::extract::State) extractor.
 ///
-/// Holds the configured LLM provider and the directory path from which static
-/// frontend assets are served.
-/// The directory defaults to the relative path `frontend/dist`, resolved
-/// against the process's current working directory (CWD) at runtime via
-/// [`resolve_static_dir`]. This only matches when the server is launched from the
-/// workspace root (e.g. via `cargo run` from the workspace root).
-///
-/// Override the default by setting the `LIBRECHAT_STATIC_DIR` environment
-/// variable or by calling [`AppState::with_static_dir`] with an absolute path
-/// at startup.
+/// Holds the configured LLM provider, the directory path from which static
+/// frontend assets are served, and an optional SQLite connection pool.
 #[derive(Clone)]
 pub struct AppState {
     /// Shared LLM provider used by API handlers.
     pub provider: Arc<dyn LlmProvider>,
     /// Directory containing static frontend files served by `ServeDir`.
     pub static_dir: PathBuf,
+    /// SQLite connection pool when persistence is enabled.
+    pub db_pool: Option<SqlitePool>,
 }
 
 struct NoopProvider;
@@ -70,18 +66,34 @@ impl LlmProvider for NoopProvider {
     }
 }
 
+/// Error type for database initialization failures.
+#[derive(Debug)]
+pub struct DatabaseInitError {
+    pub message: String,
+}
+
+impl std::fmt::Display for DatabaseInitError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}", self.message)
+    }
+}
+
+impl std::error::Error for DatabaseInitError {}
+
 impl AppState {
-    /// Creates a new `AppState` with default values.
+    /// Creates a new `AppState` with default values **without** a database pool.
     ///
     /// Resolves the static directory from the `LIBRECHAT_STATIC_DIR`
-    /// environment variable, falling back to [`DEFAULT_STATIC_DIR`]. Both
-    /// `new()` and the [`Default`] impl delegate to [`resolve_static_dir`],
-    /// which resolves the relative default against the CWD at runtime.
+    /// environment variable, falling back to [`DEFAULT_STATIC_DIR`].
+    ///
+    /// This constructor is used by integration tests that do not need
+    /// persistence, as well as by [`Default`].
     #[must_use]
     pub fn new() -> Self {
         Self {
             provider: default_provider(),
             static_dir: resolve_static_dir(),
+            db_pool: None,
         }
     }
 
@@ -89,19 +101,20 @@ impl AppState {
     ///
     /// Useful for testing where a temporary directory is needed, or for
     /// production deployments that require an absolute path to avoid
-    /// CWD-related resolution surprises.
+    /// CWD-related resolution surprises.  No database pool is created.
     #[must_use]
     pub fn with_static_dir(static_dir: PathBuf) -> Self {
         Self {
             provider: noop_provider(),
             static_dir,
+            db_pool: None,
         }
     }
 
     /// Creates an `AppState` with a specific provider and static directory.
     ///
     /// Intended for tests that need to inject a mock provider while still
-    /// exercising the real router and handlers.
+    /// exercising the real router and handlers.  No database pool is created.
     #[cfg(any(test, feature = "test-utils"))]
     #[must_use]
     pub fn with_provider_and_static_dir(
@@ -111,7 +124,53 @@ impl AppState {
         Self {
             provider,
             static_dir,
+            db_pool: None,
         }
+    }
+
+    /// Initialise an `AppState` with the default SQLite database.
+    ///
+    /// Connects to the database URL resolved by [`default_database_url`],
+    /// creates the connection pool, and runs pending migrations.  If either
+    /// step fails the error is returned so that the binary can exit with a
+    /// clear message at startup.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`DatabaseInitError`] when the pool cannot be created or
+    /// migrations fail.
+    pub async fn init() -> Result<Self, DatabaseInitError> {
+        let database_url = default_database_url();
+        let pool = init_pool(&database_url)
+            .await
+            .map_err(|e| DatabaseInitError {
+                message: format!("failed to connect to SQLite database at {database_url}: {e}"),
+            })?;
+        run_migrations(&pool).await.map_err(|e| DatabaseInitError {
+            message: format!("failed to run database migrations: {e}"),
+        })?;
+        let mut state = Self::new();
+        state.db_pool = Some(pool);
+        Ok(state)
+    }
+
+    /// Initialise an `AppState` with a specific database URL.
+    ///
+    /// Available in tests so that each test can use its own temporary database
+    /// file without mutating the global `LIBRECHAT_DATABASE_URL` variable.
+    #[cfg(any(test, feature = "test-utils"))]
+    pub async fn with_database_url(database_url: &str) -> Result<Self, DatabaseInitError> {
+        let pool = init_pool(database_url)
+            .await
+            .map_err(|e| DatabaseInitError {
+                message: format!("failed to connect to SQLite database at {database_url}: {e}"),
+            })?;
+        run_migrations(&pool).await.map_err(|e| DatabaseInitError {
+            message: format!("failed to run database migrations: {e}"),
+        })?;
+        let mut state = Self::new();
+        state.db_pool = Some(pool);
+        Ok(state)
     }
 }
 

--- a/server/tests/chat_completions.rs
+++ b/server/tests/chat_completions.rs
@@ -151,6 +151,7 @@ fn test_app(provider: Arc<dyn LlmProvider>) -> (axum::Router, TempDir) {
     .expect("write index.html");
 
     let state = AppState {
+        db_pool: None,
         provider,
         static_dir: temp_dir.path().to_path_buf(),
     };

--- a/server/tests/chat_completions_stream.rs
+++ b/server/tests/chat_completions_stream.rs
@@ -151,6 +151,7 @@ fn test_app(provider: Arc<dyn LlmProvider>) -> (axum::Router, TempDir) {
     .expect("write index.html");
 
     let state = AppState {
+        db_pool: None,
         provider,
         static_dir: temp_dir.path().to_path_buf(),
     };

--- a/server/tests/database_persistence.rs
+++ b/server/tests/database_persistence.rs
@@ -1,0 +1,102 @@
+//! Integration tests for the SQLite persistence foundation (Issue #27).
+
+use server::database::{default_database_url, init_pool, run_migrations, table_exists};
+use std::sync::Mutex;
+
+/// Mutex serialising tests that mutate the `LIBRECHAT_DATABASE_URL` environment
+/// variable. Cargo runs tests in parallel, so unsynchronised `set_var` /
+/// `remove_var` calls would cause data races.
+static ENV_LOCK: Mutex<()> = Mutex::new(());
+
+// ---- Pool initialisation ----
+
+#[tokio::test]
+async fn test_database_pool_initialization() {
+    let temp = tempfile::tempdir().expect("create temp dir");
+    let db_path = temp.path().join("test.db");
+    let url = format!("sqlite:{}", db_path.to_str().expect("path to str"));
+
+    let pool = init_pool(&url)
+        .await
+        .expect("pool initialization should succeed");
+
+    // Verify the pool is usable with a simple scalar query.
+    let row: (i64,) = sqlx::query_as("SELECT 1")
+        .fetch_one(&pool)
+        .await
+        .expect("should be able to query pool");
+    assert_eq!(row.0, 1);
+}
+
+// ---- Migration execution ----
+
+#[tokio::test]
+async fn test_migrations_run_on_startup() {
+    let temp = tempfile::tempdir().expect("create temp dir");
+    let db_path = temp.path().join("test.db");
+    let url = format!("sqlite:{}", db_path.to_str().expect("path to str"));
+
+    let pool = init_pool(&url)
+        .await
+        .expect("pool initialization should succeed");
+    run_migrations(&pool)
+        .await
+        .expect("migrations should run successfully");
+}
+
+// ---- Environment variable override ----
+
+#[tokio::test]
+async fn test_database_url_env_var_override() {
+    let _lock = ENV_LOCK.lock().expect("env lock");
+
+    let temp = tempfile::tempdir().expect("create temp dir");
+    let db_path = temp.path().join("env_test.db");
+    let url = format!("sqlite:{}", db_path.to_str().expect("path to str"));
+
+    let env_key = "LIBRECHAT_DATABASE_URL";
+    let original = std::env::var(env_key).ok();
+    // Safety: guarded by ENV_LOCK to serialise parallel test access.
+    unsafe {
+        std::env::set_var(env_key, &url);
+    }
+
+    let resolved = default_database_url();
+
+    // Restore env var
+    unsafe {
+        if let Some(val) = original {
+            std::env::set_var(env_key, val);
+        } else {
+            std::env::remove_var(env_key);
+        }
+    }
+
+    assert_eq!(
+        resolved, url,
+        "LIBRECHAT_DATABASE_URL should override the default database URL"
+    );
+}
+
+// ---- Migrated table existence ----
+
+#[tokio::test]
+async fn test_migrated_table_exists() {
+    let temp = tempfile::tempdir().expect("create temp dir");
+    let db_path = temp.path().join("test.db");
+    let url = format!("sqlite:{}", db_path.to_str().expect("path to str"));
+
+    let pool = init_pool(&url)
+        .await
+        .expect("pool initialization should succeed");
+    run_migrations(&pool)
+        .await
+        .expect("migrations should run successfully");
+
+    // Verify at least one expected table exists using a compile-time checked query.
+    let exists = table_exists(&pool, "conversations")
+        .await
+        .expect("should be able to query sqlite_master");
+
+    assert!(exists, "conversations table should exist after migrations");
+}

--- a/server/tests/database_persistence.rs
+++ b/server/tests/database_persistence.rs
@@ -1,12 +1,6 @@
 //! Integration tests for the SQLite persistence foundation (Issue #27).
 
 use server::database::{default_database_url, init_pool, run_migrations, table_exists};
-use std::sync::Mutex;
-
-/// Mutex serialising tests that mutate the `LIBRECHAT_DATABASE_URL` environment
-/// variable. Cargo runs tests in parallel, so unsynchronised `set_var` /
-/// `remove_var` calls would cause data races.
-static ENV_LOCK: Mutex<()> = Mutex::new(());
 
 // ---- Pool initialisation ----
 
@@ -47,8 +41,9 @@ async fn test_migrations_run_on_startup() {
 // ---- Environment variable override ----
 
 #[tokio::test]
+#[serial_test::serial]
 async fn test_database_url_env_var_override() {
-    let _lock = ENV_LOCK.lock().expect("env lock");
+    // serial_test::serial guarantees exclusive access to env var mutations.
 
     let temp = tempfile::tempdir().expect("create temp dir");
     let db_path = temp.path().join("env_test.db");
@@ -56,7 +51,7 @@ async fn test_database_url_env_var_override() {
 
     let env_key = "LIBRECHAT_DATABASE_URL";
     let original = std::env::var(env_key).ok();
-    // Safety: guarded by ENV_LOCK to serialise parallel test access.
+    // Safety: guarded by #[serial_test::serial] to serialise parallel test access.
     unsafe {
         std::env::set_var(env_key, &url);
     }

--- a/wiki/sqlite-persistence.md
+++ b/wiki/sqlite-persistence.md
@@ -16,6 +16,7 @@ first building block of Phase 2; future updates will add a full chat-history
 UI and richer settings screens on top of this foundation.
 
 ### Who benefits?
+
 - **End users** who want their chat history to persist across server restarts.
 - **Self-hosters** running LibreChat on a Raspberry Pi or low-power device,
   because SQLite is extremely lightweight and requires no separate database
@@ -71,26 +72,31 @@ cargo run -p server
 
 ## FAQ / Troubleshooting
 
-### Q: The server fails to start with a "database initialisation" error.  
+### Q: The server fails to start with a "database initialisation" error.
+
 **A:** Make sure the directory where the database file lives is writable.  If
 you set a custom `LIBRECHAT_DATABASE_URL`, check that the parent directory
 exists.  The default path `librechat.db` requires write permission in the
 folder where you run the server.
 
-### Q: Can I use PostgreSQL or MySQL instead?  
+### Q: Can I use PostgreSQL or MySQL instead?
+
 **A:** Not with this issue.  The foundation is intentionally SQLite-only to
 keep the project small and portable.  Remote database support may be explored
 in a later Phase.
 
-### Q: Where is my data?  
+### Q: Where is my data?
+
 **A:** By default, in a file called `librechat.db` in the same folder you
 start the server from.  You can open it with any SQLite viewer or the
 `sqlite3` command-line tool.
 
-### Q: Do I need to run migration scripts manually?  
+### Q: Do I need to run migration scripts manually?
+
 **A:** No.  Migrations run automatically every time the server starts.
 
-### Q: Will the database work on a Raspberry Pi?  
+### Q: Will the database work on a Raspberry Pi?
+
 **A:** Yes.  SQLite is one of the most resource-efficient databases
 available and is widely used on embedded devices.
 

--- a/wiki/sqlite-persistence.md
+++ b/wiki/sqlite-persistence.md
@@ -1,0 +1,104 @@
+# SQLite Persistence Foundation
+
+**What it does:**  
+LibreChat now remembers your conversations, messages, and preferences by
+storing them in a local SQLite database file instead of keeping everything in
+memory.  When you restart the server, your chat threads and settings survive.
+
+---
+
+## Feature Overview
+
+Before this change, LibreChat lost all chat history and settings every time
+the server restarted.  The SQLite persistence foundation introduces a small,
+local database that lives on disk right next to the application.  It is the
+first building block of Phase 2; future updates will add a full chat-history
+UI and richer settings screens on top of this foundation.
+
+### Who benefits?
+- **End users** who want their chat history to persist across server restarts.
+- **Self-hosters** running LibreChat on a Raspberry Pi or low-power device,
+  because SQLite is extremely lightweight and requires no separate database
+  server.
+
+---
+
+## User Guide
+
+### Starting the server for the first time
+
+No manual setup is required.  Simply run the server as usual:
+
+```bash
+cargo run -p server
+```
+
+On first startup LibreChat will:
+1. Create a file named `librechat.db` in the working directory.
+2. Set up the tables needed for conversations, messages, and preferences.
+
+### Using a custom database location
+
+If you want the database file somewhere else (for example, on a larger disk
+or in a backup-friendly path), set the environment variable before starting:
+
+```bash
+export LIBRECHAT_DATABASE_URL="sqlite:/path/to/my/librechat.db"
+cargo run -p server
+```
+
+### What is stored?
+
+| Data | Table | Notes |
+|------|-------|-------|
+| Chat threads | `conversations` | One row per thread, with a title and timestamps. |
+| Individual messages | `messages` | Linked to a conversation; stores who sent it (`user` or `assistant`) and the text. |
+| App theme / language | `user_settings` | Global preferences (single row). |
+| Preferred model | `model_preferences` | Which provider and model to use by default (single row). |
+
+---
+
+## Glossary
+
+| Term | Meaning |
+|------|---------|
+| **SQLite** | A small, file-based database engine built into the application.  No separate installation needed. |
+| **SQLx** | The Rust library used to talk to SQLite.  It checks SQL queries for correctness while the code is being built. |
+| **Migration** | A script that creates or updates database tables.  Migrations run automatically when the server starts. |
+| **Pool** | A group of reusable database connections.  It makes the server faster and more reliable under load. |
+
+---
+
+## FAQ / Troubleshooting
+
+### Q: The server fails to start with a "database initialisation" error.  
+**A:** Make sure the directory where the database file lives is writable.  If
+you set a custom `LIBRECHAT_DATABASE_URL`, check that the parent directory
+exists.  The default path `librechat.db` requires write permission in the
+folder where you run the server.
+
+### Q: Can I use PostgreSQL or MySQL instead?  
+**A:** Not with this issue.  The foundation is intentionally SQLite-only to
+keep the project small and portable.  Remote database support may be explored
+in a later Phase.
+
+### Q: Where is my data?  
+**A:** By default, in a file called `librechat.db` in the same folder you
+start the server from.  You can open it with any SQLite viewer or the
+`sqlite3` command-line tool.
+
+### Q: Do I need to run migration scripts manually?  
+**A:** No.  Migrations run automatically every time the server starts.
+
+### Q: Will the database work on a Raspberry Pi?  
+**A:** Yes.  SQLite is one of the most resource-efficient databases
+available and is widely used on embedded devices.
+
+---
+
+## Related Resources
+
+- **Technical docs:** [`docs/sqlite-persistence.md`](docs/sqlite-persistence.md)
+- **SQLx compile-time query docs:** https://docs.rs/sqlx/latest/sqlx/macro.query.html
+- **SQLite syntax:** https://www.sqlite.org/lang.html
+- **Next planned feature:** Chat history UI (issue coming in Phase 2)

--- a/wiki/sqlite-persistence.md
+++ b/wiki/sqlite-persistence.md
@@ -98,7 +98,7 @@ available and is widely used on embedded devices.
 
 ## Related Resources
 
-- **Technical docs:** [`docs/sqlite-persistence.md`](docs/sqlite-persistence.md)
+- **Technical docs:** [`docs/sqlite-persistence.md`](../docs/sqlite-persistence.md)
 - **SQLx compile-time query docs:** https://docs.rs/sqlx/latest/sqlx/macro.query.html
 - **SQLite syntax:** https://www.sqlite.org/lang.html
 - **Next planned feature:** Chat history UI (issue coming in Phase 2)


### PR DESCRIPTION
## What changed

This PR implements the SQLite persistence foundation for LibreChat Phase 2 (closes #27).

- **Added `sqlx`** to the workspace and `server` crate with minimal features for SQLite, Tokio, migrations, and compile-time checked queries.
- **Created `server/src/database.rs`** — a small module that owns pool creation, migration execution, and database URL resolution.
- **Created `server/migrations/1_initial_schema.sql`** — initial schema for `conversations`, `messages`, `user_settings`, and `model_preferences`.
- **Wired the SQLx pool into `AppState`** via an optional `db_pool: Option<SqlitePool>` field so existing route tests that inject mock providers or temporary static dirs continue to compile and pass.
- **Updated `server/src/main.rs`** to call `AppState::init().await` on startup, which creates/opens the SQLite database, runs migrations, and fails with a clear error message if anything goes wrong.
- **Added compile-time checked query** (`table_exists`) and generated offline metadata in `.sqlx/` so the project compiles without a live `DATABASE_URL`.
- **Added integration tests** covering pool initialization, migration execution, env-var database URL override, and migrated table existence.
- **Added documentation** in `docs/sqlite-persistence.md` (technical) and `wiki/sqlite-persistence.md` (user-facing).

## Why it changed

The app currently keeps all chat threads, settings, and model preferences in memory. This foundation adds a local SQLite-backed persistence layer so that later Phase 2 issues can build repository functions, chat-history APIs, and UI integration on top of it.

## Impact

- Fresh checkouts can start the server and initialize the database without manual SQL steps.
- Existing tests are unaffected; no breaking changes to HTTP routes or `AppState` constructors used by tests.
- The default database path is `librechat.db` in the working directory, overridable via `LIBRECHAT_DATABASE_URL`.

## Verification

- `cargo test --workspace` ✅
- `cargo fmt --all` ✅
- `cargo clippy --workspace --all-targets` ✅
- `cargo test -p server --test database_persistence` ✅


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added SQLite persistence for conversations, messages and preferences with automatic initial schema and migrations on startup.
  * Server now initialises the database at startup and exits with a visible error if initialisation fails; database URL can be overridden via LIBRECHAT_DATABASE_URL.

* **Documentation**
  * New guides detailing setup, configuration, migrations and troubleshooting for SQLite persistence.

* **Tests**
  * Integration tests added to validate pool creation, migrations and table existence.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/BhavsarDevansh/librechat/pull/31)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->